### PR TITLE
fix gitignore to include workspace audit package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ node_modules/
 .DS_Store
 .idea/
 data/
-audit/
+/audit/
 *.db
 dist/

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@delegate/audit",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@delegate/domain": "workspace:*",
+    "@delegate/ports": "workspace:*"
+  }
+}

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -1,0 +1,23 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { AuditEvent } from "@delegate/domain";
+import type { AuditPort } from "@delegate/ports";
+
+export class JsonlAuditPort implements AuditPort {
+  constructor(private readonly logPath: string) {}
+
+  async init(): Promise<void> {
+    await mkdir(dirname(this.logPath), { recursive: true });
+    await appendFile(this.logPath, "", "utf8");
+  }
+
+  async ping(): Promise<void> {
+    await appendFile(this.logPath, "", "utf8");
+  }
+
+  async append(event: AuditEvent): Promise<void> {
+    const line = JSON.stringify(event);
+    await appendFile(this.logPath, `${line}\n`, "utf8");
+  }
+}


### PR DESCRIPTION
## Summary
- Describe what changed and why.

## Validation
- [ ] `bun run verify`
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run format:check`
- [ ] `bun run build`
- [ ] `bun run test`
- [ ] `bun run docs:check`

## Safety
- [ ] No secrets or credentials added
- [ ] Scope is focused and reviewable
