### PR TITLE
implement m2 telegram delegation and planning slice

### DIFF
--- a/apps/assistant-core/package.json
+++ b/apps/assistant-core/package.json
@@ -9,7 +9,9 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@delegate/adapters-model-stub": "workspace:*",
     "@delegate/adapters-sqlite": "workspace:*",
+    "@delegate/adapters-telegram": "workspace:*",
     "@delegate/audit": "workspace:*",
     "@delegate/domain": "workspace:*",
     "@delegate/ports": "workspace:*",

--- a/apps/assistant-core/src/config.ts
+++ b/apps/assistant-core/src/config.ts
@@ -7,6 +7,8 @@ export type AppConfig = {
   enableInternalRoutes: boolean;
   sqlitePath: string;
   auditLogPath: string;
+  telegramBotToken: string | null;
+  telegramPollIntervalMs: number;
 };
 
 const defaultSqlitePath = "~/.local/share/delegate-assistant/data/assistant.db";
@@ -30,8 +32,20 @@ export const loadConfig = (): AppConfig => {
   }
 
   const nodeEnv = process.env.NODE_ENV ?? "development";
+  const telegramPollIntervalMs = Number(
+    process.env.TELEGRAM_POLL_INTERVAL_MS ?? "2000",
+  );
+
+  if (
+    !Number.isInteger(telegramPollIntervalMs) ||
+    telegramPollIntervalMs <= 0
+  ) {
+    throw new Error("TELEGRAM_POLL_INTERVAL_MS must be a positive integer");
+  }
+
   const enableInternalRoutes =
     process.env.ENABLE_INTERNAL_ROUTES === "true" || nodeEnv === "development";
+  const telegramBotToken = process.env.TELEGRAM_BOT_TOKEN?.trim() || null;
 
   return {
     port,
@@ -39,5 +53,7 @@ export const loadConfig = (): AppConfig => {
     enableInternalRoutes,
     sqlitePath: expandHome(process.env.SQLITE_PATH ?? defaultSqlitePath),
     auditLogPath: expandHome(process.env.AUDIT_LOG_PATH ?? defaultAuditPath),
+    telegramBotToken,
+    telegramPollIntervalMs,
   };
 };

--- a/apps/assistant-core/src/main.ts
+++ b/apps/assistant-core/src/main.ts
@@ -1,14 +1,18 @@
+import { DeterministicModelStub } from "@delegate/adapters-model-stub";
 import { SqliteWorkItemStore } from "@delegate/adapters-sqlite";
+import { TelegramLongPollingAdapter } from "@delegate/adapters-telegram";
 import { JsonlAuditPort } from "@delegate/audit";
 import { Effect } from "effect";
 
 import { loadConfig } from "./config";
 import { startHttpServer } from "./http";
+import { startTelegramWorker } from "./worker";
 
 const config = loadConfig();
 
 const workItemStore = new SqliteWorkItemStore(config.sqlitePath);
 const auditPort = new JsonlAuditPort(config.auditLogPath);
+const modelPort = new DeterministicModelStub();
 
 const boot = Effect.gen(function* () {
   yield* Effect.tryPromise({
@@ -29,11 +33,30 @@ const boot = Effect.gen(function* () {
     auditPort,
   });
 
+  if (config.telegramBotToken) {
+    const telegramPort = new TelegramLongPollingAdapter(
+      config.telegramBotToken,
+    );
+    void startTelegramWorker(
+      {
+        chatPort: telegramPort,
+        modelPort,
+        workItemStore,
+        planStore: workItemStore,
+        auditPort,
+      },
+      config.telegramPollIntervalMs,
+    );
+  } else {
+    console.log("telegram worker disabled: TELEGRAM_BOT_TOKEN is not set");
+  }
+
   return {
     port: config.port,
     sqlitePath: config.sqlitePath,
     auditLogPath: config.auditLogPath,
     internalRoutesEnabled: config.enableInternalRoutes,
+    telegramWorkerEnabled: config.telegramBotToken !== null,
   };
 });
 

--- a/apps/assistant-core/src/worker.test.ts
+++ b/apps/assistant-core/src/worker.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  AuditEvent,
+  ExecutionPlan,
+  ExecutionPlanDraft,
+  InboundMessage,
+  OutboundMessage,
+  WorkItem,
+  WorkItemStatus,
+} from "@delegate/domain";
+import type {
+  AuditPort,
+  ChatPort,
+  ChatUpdate,
+  ModelPort,
+  PlanInput,
+  PlanStore,
+  WorkItemStore,
+} from "@delegate/ports";
+
+import { handleChatMessage, parseCommand } from "./worker";
+
+class InMemoryWorkItemStore implements WorkItemStore {
+  private readonly items = new Map<string, WorkItem>();
+
+  async init(): Promise<void> {}
+
+  async ping(): Promise<void> {}
+
+  async create(workItem: WorkItem): Promise<void> {
+    this.items.set(workItem.id, workItem);
+  }
+
+  async getById(id: string): Promise<WorkItem | null> {
+    return this.items.get(id) ?? null;
+  }
+
+  async updateStatus(
+    id: string,
+    status: WorkItemStatus,
+    updatedAt: string,
+  ): Promise<void> {
+    const existing = this.items.get(id);
+    if (!existing) {
+      return;
+    }
+    this.items.set(id, {
+      ...existing,
+      status,
+      updatedAt,
+    });
+  }
+
+  all(): WorkItem[] {
+    return [...this.items.values()];
+  }
+}
+
+class InMemoryPlanStore implements PlanStore {
+  private readonly plans = new Map<string, ExecutionPlan>();
+
+  async createPlan(plan: ExecutionPlan): Promise<void> {
+    this.plans.set(plan.workItemId, plan);
+  }
+
+  async getPlanByWorkItemId(workItemId: string): Promise<ExecutionPlan | null> {
+    return this.plans.get(workItemId) ?? null;
+  }
+}
+
+class CapturingChatPort implements ChatPort {
+  readonly sent: OutboundMessage[] = [];
+
+  async receiveUpdates(_cursor: number | null): Promise<ChatUpdate[]> {
+    return [];
+  }
+
+  async send(message: OutboundMessage): Promise<void> {
+    this.sent.push(message);
+  }
+}
+
+class CapturingAuditPort implements AuditPort {
+  readonly events: AuditEvent[] = [];
+
+  async init(): Promise<void> {}
+
+  async ping(): Promise<void> {}
+
+  async append(event: AuditEvent): Promise<void> {
+    this.events.push(event);
+  }
+}
+
+class HighRiskModelStub implements ModelPort {
+  async plan(_input: PlanInput): Promise<ExecutionPlanDraft> {
+    return {
+      intentSummary: "Publish a PR with requested changes",
+      assumptions: ["Repository access is configured"],
+      ambiguities: ["Target branch not specified"],
+      proposedNextStep: "Review patch and request approval",
+      riskLevel: "HIGH",
+      sideEffects: ["local_code_changes", "external_publish"],
+      requiresApproval: true,
+    };
+  }
+}
+
+const inbound = (text: string): InboundMessage => ({
+  chatId: "123",
+  text,
+  receivedAt: new Date().toISOString(),
+});
+
+describe("parseCommand", () => {
+  test("parses slash commands", () => {
+    expect(parseCommand("/status work-1")).toEqual({
+      type: "status",
+      workItemId: "work-1",
+    });
+  });
+
+  test("falls back to delegation for plain text", () => {
+    expect(parseCommand("ship this change")).toEqual({
+      type: "delegate",
+      text: "ship this change",
+    });
+  });
+});
+
+describe("handleChatMessage", () => {
+  test("creates work item, persists plan, and responds with preview", async () => {
+    const workItemStore = new InMemoryWorkItemStore();
+    const planStore = new InMemoryPlanStore();
+    const chatPort = new CapturingChatPort();
+    const auditPort = new CapturingAuditPort();
+
+    await handleChatMessage(
+      {
+        chatPort,
+        modelPort: new HighRiskModelStub(),
+        workItemStore,
+        planStore,
+        auditPort,
+      },
+      inbound("Please publish a PR for this refactor"),
+    );
+
+    const items = workItemStore.all();
+    expect(items.length).toBe(1);
+    expect(items[0]?.status).toBe("triaged");
+
+    const plan = await planStore.getPlanByWorkItemId(items[0]!.id);
+    expect(plan?.requiresApproval).toBe(true);
+    expect(chatPort.sent[0]?.text.includes("Approval preview")).toBe(true);
+    expect(auditPort.events.map((event) => event.eventType)).toEqual([
+      "work_item.delegated",
+      "plan.created",
+      "work_item.triaged",
+    ]);
+  });
+
+  test("returns status for existing work item", async () => {
+    const workItemStore = new InMemoryWorkItemStore();
+    const planStore = new InMemoryPlanStore();
+    const chatPort = new CapturingChatPort();
+
+    await workItemStore.create({
+      id: "work-123",
+      traceId: "trace-123",
+      status: "triaged",
+      summary: "A task",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    await handleChatMessage(
+      {
+        chatPort,
+        modelPort: new HighRiskModelStub(),
+        workItemStore,
+        planStore,
+        auditPort: new CapturingAuditPort(),
+      },
+      inbound("/status work-123"),
+    );
+
+    expect(chatPort.sent[0]?.text).toContain("status=triaged");
+  });
+});

--- a/apps/assistant-core/src/worker.ts
+++ b/apps/assistant-core/src/worker.ts
@@ -1,0 +1,260 @@
+import type {
+  AuditEvent,
+  ExecutionPlan,
+  InboundMessage,
+  WorkItem,
+} from "@delegate/domain";
+import type {
+  AuditPort,
+  ChatPort,
+  ModelPort,
+  PlanStore,
+  WorkItemStore,
+} from "@delegate/ports";
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const nowIso = (): string => new Date().toISOString();
+
+type Command =
+  | { type: "approve"; approvalId: string | null }
+  | { type: "deny"; approvalId: string | null }
+  | { type: "status"; workItemId: string | null }
+  | { type: "explain"; workItemId: string | null }
+  | { type: "delegate"; text: string };
+
+type WorkerDeps = {
+  chatPort: ChatPort;
+  modelPort: ModelPort;
+  workItemStore: WorkItemStore;
+  planStore: PlanStore;
+  auditPort: AuditPort;
+};
+
+export const parseCommand = (text: string): Command => {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("/")) {
+    return { type: "delegate", text: trimmed };
+  }
+
+  const [command, rawArg] = trimmed.split(/\s+/, 2);
+  const arg = rawArg?.trim() || null;
+
+  switch (command.toLowerCase()) {
+    case "/approve":
+      return { type: "approve", approvalId: arg };
+    case "/deny":
+      return { type: "deny", approvalId: arg };
+    case "/status":
+      return { type: "status", workItemId: arg };
+    case "/explain":
+      return { type: "explain", workItemId: arg };
+    default:
+      return { type: "delegate", text: trimmed };
+  }
+};
+
+const summarize = (text: string): string => {
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= 140) {
+    return collapsed;
+  }
+  return `${collapsed.slice(0, 137)}...`;
+};
+
+const formatPlanResponse = (
+  workItem: WorkItem,
+  plan: ExecutionPlan,
+): string => {
+  const lines = [
+    `Work item ${workItem.id}`,
+    `Intent: ${plan.intentSummary}`,
+    `Assumptions: ${plan.assumptions.join("; ")}`,
+    `Ambiguities: ${plan.ambiguities.join("; ")}`,
+    `Next: ${plan.proposedNextStep}`,
+  ];
+
+  if (plan.requiresApproval) {
+    lines.push(
+      `Approval preview: risk ${plan.riskLevel}; side effects ${plan.sideEffects.join(", ")}; would expire in 24h (enforced in M3).`,
+    );
+  }
+
+  lines.push(`Check progress: /status ${workItem.id}`);
+  return lines.join("\n");
+};
+
+const appendAuditEvent = async (
+  auditPort: AuditPort,
+  event: AuditEvent,
+): Promise<void> => {
+  await auditPort.append(event);
+};
+
+export const handleChatMessage = async (
+  deps: WorkerDeps,
+  message: InboundMessage,
+): Promise<void> => {
+  const command = parseCommand(message.text);
+
+  if (command.type === "status") {
+    if (!command.workItemId) {
+      await deps.chatPort.send({
+        chatId: message.chatId,
+        text: "Usage: /status <workItemId>",
+      });
+      return;
+    }
+
+    const workItem = await deps.workItemStore.getById(command.workItemId);
+    if (!workItem) {
+      await deps.chatPort.send({
+        chatId: message.chatId,
+        text: `No work item found for id ${command.workItemId}.`,
+      });
+      return;
+    }
+
+    const plan = await deps.planStore.getPlanByWorkItemId(command.workItemId);
+    await deps.chatPort.send({
+      chatId: message.chatId,
+      text: `Work item ${workItem.id}: status=${workItem.status}; plan=${plan ? "ready" : "pending"}`,
+    });
+    return;
+  }
+
+  if (command.type === "approve") {
+    await deps.chatPort.send({
+      chatId: message.chatId,
+      text: `Approval flow activates in M3. Received approval id: ${command.approvalId ?? "(missing)"}.`,
+    });
+    return;
+  }
+
+  if (command.type === "deny") {
+    await deps.chatPort.send({
+      chatId: message.chatId,
+      text: `Denial flow activates in M3. Received approval id: ${command.approvalId ?? "(missing)"}.`,
+    });
+    return;
+  }
+
+  if (command.type === "explain") {
+    await deps.chatPort.send({
+      chatId: message.chatId,
+      text: `Explain output activates in M5. For now use /status ${command.workItemId ?? "<workItemId>"}.`,
+    });
+    return;
+  }
+
+  if (!command.text) {
+    await deps.chatPort.send({
+      chatId: message.chatId,
+      text: "Please send a request with some detail.",
+    });
+    return;
+  }
+
+  const timestamp = nowIso();
+  const workItem: WorkItem = {
+    id: crypto.randomUUID(),
+    traceId: crypto.randomUUID(),
+    status: "delegated",
+    summary: summarize(command.text),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+
+  await deps.workItemStore.create(workItem);
+  await appendAuditEvent(deps.auditPort, {
+    eventId: crypto.randomUUID(),
+    eventType: "work_item.delegated",
+    workItemId: workItem.id,
+    actor: "user",
+    timestamp,
+    traceId: workItem.traceId,
+    payload: {
+      source: "telegram",
+      text: command.text,
+      chatId: message.chatId,
+    },
+  });
+
+  const draft = await deps.modelPort.plan({
+    workItemId: workItem.id,
+    text: command.text,
+  });
+
+  const plan: ExecutionPlan = {
+    id: crypto.randomUUID(),
+    workItemId: workItem.id,
+    createdAt: nowIso(),
+    ...draft,
+  };
+
+  await deps.planStore.createPlan(plan);
+  await deps.workItemStore.updateStatus(workItem.id, "triaged", nowIso());
+
+  await appendAuditEvent(deps.auditPort, {
+    eventId: crypto.randomUUID(),
+    eventType: "plan.created",
+    workItemId: workItem.id,
+    actor: "assistant",
+    timestamp: nowIso(),
+    traceId: workItem.traceId,
+    payload: {
+      planId: plan.id,
+      riskLevel: plan.riskLevel,
+      requiresApproval: plan.requiresApproval,
+    },
+  });
+
+  await appendAuditEvent(deps.auditPort, {
+    eventId: crypto.randomUUID(),
+    eventType: "work_item.triaged",
+    workItemId: workItem.id,
+    actor: "assistant",
+    timestamp: nowIso(),
+    traceId: workItem.traceId,
+    payload: {
+      status: "triaged",
+      planId: plan.id,
+    },
+  });
+
+  await deps.chatPort.send({
+    chatId: message.chatId,
+    text: formatPlanResponse(
+      { ...workItem, status: "triaged", updatedAt: nowIso() },
+      plan,
+    ),
+  });
+};
+
+export const startTelegramWorker = (
+  deps: WorkerDeps,
+  pollIntervalMs: number,
+): Promise<never> => {
+  let cursor: number | null = null;
+
+  const loop = async (): Promise<never> => {
+    while (true) {
+      try {
+        const updates = await deps.chatPort.receiveUpdates(cursor);
+        for (const update of updates) {
+          cursor = update.updateId + 1;
+          await handleChatMessage(deps, update.message);
+        }
+      } catch (error) {
+        console.error("telegram worker cycle failed", error);
+      }
+
+      await sleep(pollIntervalMs);
+    }
+  };
+
+  return loop();
+};

--- a/bun.lock
+++ b/bun.lock
@@ -17,15 +17,31 @@
     "apps/assistant-core": {
       "name": "@delegate/assistant-core",
       "dependencies": {
+        "@delegate/adapters-model-stub": "workspace:*",
         "@delegate/adapters-sqlite": "workspace:*",
+        "@delegate/adapters-telegram": "workspace:*",
         "@delegate/audit": "workspace:*",
         "@delegate/domain": "workspace:*",
         "@delegate/ports": "workspace:*",
         "effect": "^3.17.14",
       },
     },
+    "packages/adapters-model-stub": {
+      "name": "@delegate/adapters-model-stub",
+      "dependencies": {
+        "@delegate/domain": "workspace:*",
+        "@delegate/ports": "workspace:*",
+      },
+    },
     "packages/adapters-sqlite": {
       "name": "@delegate/adapters-sqlite",
+      "dependencies": {
+        "@delegate/domain": "workspace:*",
+        "@delegate/ports": "workspace:*",
+      },
+    },
+    "packages/adapters-telegram": {
+      "name": "@delegate/adapters-telegram",
       "dependencies": {
         "@delegate/domain": "workspace:*",
         "@delegate/ports": "workspace:*",
@@ -71,7 +87,11 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ=="],
 
+    "@delegate/adapters-model-stub": ["@delegate/adapters-model-stub@workspace:packages/adapters-model-stub"],
+
     "@delegate/adapters-sqlite": ["@delegate/adapters-sqlite@workspace:packages/adapters-sqlite"],
+
+    "@delegate/adapters-telegram": ["@delegate/adapters-telegram@workspace:packages/adapters-telegram"],
 
     "@delegate/assistant-core": ["@delegate/assistant-core@workspace:apps/assistant-core"],
 

--- a/docs/00-09_meta/00-index.md
+++ b/docs/00-09_meta/00-index.md
@@ -2,6 +2,12 @@
 
 Knowledge Index (Johnny Decimal)
 
+## Current v0 Status
+- M1 Foundation Tracer Bullet: complete
+- M2 Telegram Delegation + Planning: complete
+- M3 Policy + Approval Integrity: next
+- CI quality gate is active: `bun run verify`
+
 ## 00-09 Meta
 - `docs/00-09_meta/00-index.md` - master docs index (this file)
 - `docs/00-09_meta/01-doc-conventions.md` - numbering, status, and update rules

--- a/docs/30-39_execution/30-v0-working-plan.md
+++ b/docs/30-39_execution/30-v0-working-plan.md
@@ -5,6 +5,13 @@ Status: active
 ## Purpose
 Provide an execution-first plan for delivering v0 in small vertical slices with strict approval gates and full auditability.
 
+## Milestone Status
+- M1 Foundation Tracer Bullet: complete
+- M2 Telegram Delegation + Planning: complete
+- M3 Policy + Approval Integrity: next
+- M4 Approval-Gated GitHub PR Publish: not started
+- M5 Explainability, Recovery, and Test Matrix: not started
+
 ## Non-Goals (v0)
 - Autonomous monitoring loops
 - Automatic email sending
@@ -90,7 +97,14 @@ Exit criteria:
 - No externally visible side effects without approval
 - Assistant identity separation preserved
 - Full traceability for delegated workflows
-- Feedback loops green: `typecheck`, `test`, `lint`
+- Feedback loops green via `bun run verify` (`typecheck`, `lint`, `format:check`, `build`, `test`, `docs:check`)
+
+## CI Contract
+- Single quality gate command: `bun run verify`
+- CI workflow trigger policy:
+  - `pull_request` on all branches
+  - `push` on `main`
+- CI execution policy: fail fast and strict (warnings or check failures fail the run)
 
 ## Progress Log
 
@@ -100,6 +114,12 @@ Template:
 - Decisions:
 - Files changed:
 - Blockers/notes:
+
+2026-02-07
+- Completed: M2 Telegram delegation + planning slice with real Telegram long polling adapter, deterministic planner stub, persisted plans, command router, and status responses.
+- Decisions: Deferred real OpenAI integration; `/status` is functional in M2 while `/approve` and `/deny` return explicit M3 placeholders; approval preview includes fixed "would expire in 24h" copy.
+- Files changed: `apps/assistant-core/src/main.ts`, `apps/assistant-core/src/config.ts`, `apps/assistant-core/src/worker.ts`, `apps/assistant-core/src/worker.test.ts`, `apps/assistant-core/package.json`, `packages/domain/src/index.ts`, `packages/ports/src/index.ts`, `packages/adapters-sqlite/src/index.ts`, `packages/adapters-sqlite/src/index.test.ts`, `packages/adapters-telegram/package.json`, `packages/adapters-telegram/src/index.ts`, `packages/adapters-model-stub/package.json`, `packages/adapters-model-stub/src/index.ts`.
+- Blockers/notes: `TELEGRAM_BOT_TOKEN` is required to run live polling; worker remains disabled when token is unset.
 
 2026-02-07
 - Completed: Refactored docs to Johnny Decimal structure and created active v0 working plan.

--- a/docs/30-39_execution/31-v0-implementation-blueprint.md
+++ b/docs/30-39_execution/31-v0-implementation-blueprint.md
@@ -4,6 +4,15 @@ Status: active
 
 This document defines the concrete build plan, package layout, and implementation contracts for v0.
 
+## Implementation Notes (Current)
+
+- M1 is implemented as a lean tracer bullet first.
+- HTTP in M1 uses Bun's native server (`Bun.serve`) with Effect orchestration, while preserving ports/adapters boundaries.
+- M1 persistence uses startup schema initialization for core tables (`work_items`, `audit_events`) before introducing a full migration runner.
+- Quality gates are centralized under `bun run verify` and enforced in CI.
+- M2 is implemented with real Telegram long polling and a deterministic `ModelPort.plan` stub; real OpenAI integration is deferred.
+- M2 command behavior: `/status` is active, while `/approve` and `/deny` are explicit placeholders until M3 approval integrity is wired.
+
 ## 1. Monorepo Layout
 
 ```text

--- a/packages/adapters-model-stub/package.json
+++ b/packages/adapters-model-stub/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@delegate/adapters-model-stub",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@delegate/domain": "workspace:*",
+    "@delegate/ports": "workspace:*"
+  }
+}

--- a/packages/adapters-model-stub/src/index.ts
+++ b/packages/adapters-model-stub/src/index.ts
@@ -1,0 +1,37 @@
+import type { ExecutionPlanDraft } from "@delegate/domain";
+import type { ModelPort, PlanInput } from "@delegate/ports";
+
+const includesAny = (text: string, needles: string[]): boolean =>
+  needles.some((needle) => text.includes(needle));
+
+export class DeterministicModelStub implements ModelPort {
+  async plan(input: PlanInput): Promise<ExecutionPlanDraft> {
+    const normalized = input.text.toLowerCase();
+
+    const highRisk = includesAny(normalized, [
+      "publish",
+      "pr",
+      "merge",
+      "deploy",
+      "delete",
+      "send",
+    ]);
+
+    return {
+      intentSummary: `Plan delegated request: ${input.text.slice(0, 140)}`,
+      assumptions: [
+        "Repository access and local tooling are available.",
+        "Proposed changes will be validated before external publish.",
+      ],
+      ambiguities: ["Exact acceptance criteria may need confirmation."],
+      proposedNextStep: highRisk
+        ? "Review the proposed patch and request approval before publish."
+        : "Review the plan and confirm implementation scope.",
+      riskLevel: highRisk ? "HIGH" : "MEDIUM",
+      sideEffects: highRisk
+        ? ["local_code_changes", "external_publish"]
+        : ["local_code_changes"],
+      requiresApproval: highRisk,
+    };
+  }
+}

--- a/packages/adapters-sqlite/src/index.test.ts
+++ b/packages/adapters-sqlite/src/index.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { ExecutionPlan, WorkItem } from "@delegate/domain";
+
+import { SqliteWorkItemStore } from "./index";
+
+describe("SqliteWorkItemStore", () => {
+  let dirPath = "";
+  let dbPath = "";
+  let store: SqliteWorkItemStore;
+
+  beforeEach(async () => {
+    dirPath = await mkdtemp(join(tmpdir(), "delegate-assistant-test-"));
+    dbPath = join(dirPath, "assistant.db");
+    store = new SqliteWorkItemStore(dbPath);
+    await store.init();
+  });
+
+  afterEach(async () => {
+    await rm(dirPath, { recursive: true, force: true });
+  });
+
+  test("persists and reads plans by work item id", async () => {
+    const now = new Date().toISOString();
+    const workItem: WorkItem = {
+      id: "work-item-1",
+      traceId: "trace-1",
+      status: "delegated",
+      summary: "Rename function and open PR",
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const plan: ExecutionPlan = {
+      id: "plan-1",
+      workItemId: workItem.id,
+      createdAt: now,
+      intentSummary: "Create a small rename patch",
+      assumptions: ["Repository is available"],
+      ambiguities: ["Target branch not specified"],
+      proposedNextStep: "Prepare a patch for review",
+      riskLevel: "HIGH",
+      sideEffects: ["local_code_changes", "external_publish"],
+      requiresApproval: true,
+    };
+
+    await store.create(workItem);
+    await store.createPlan(plan);
+    await store.updateStatus(workItem.id, "triaged", now);
+
+    const savedWorkItem = await store.getById(workItem.id);
+    const savedPlan = await store.getPlanByWorkItemId(workItem.id);
+
+    expect(savedWorkItem?.status).toBe("triaged");
+    expect(savedPlan).toEqual(plan);
+  });
+});

--- a/packages/adapters-sqlite/src/index.ts
+++ b/packages/adapters-sqlite/src/index.ts
@@ -2,8 +2,12 @@ import { Database } from "bun:sqlite";
 import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 
-import type { WorkItem } from "@delegate/domain";
-import type { WorkItemStore } from "@delegate/ports";
+import type {
+  ExecutionPlan,
+  PlanSideEffectType,
+  WorkItem,
+} from "@delegate/domain";
+import type { PlanStore, WorkItemStore } from "@delegate/ports";
 
 type WorkItemRow = {
   id: string;
@@ -14,7 +18,20 @@ type WorkItemRow = {
   updated_at: string;
 };
 
-export class SqliteWorkItemStore implements WorkItemStore {
+type PlanRow = {
+  id: string;
+  work_item_id: string;
+  intent_summary: string;
+  assumptions_json: string;
+  ambiguities_json: string;
+  proposed_next_step: string;
+  risk_level: string;
+  side_effects_json: string;
+  requires_approval: number;
+  created_at: string;
+};
+
+export class SqliteWorkItemStore implements WorkItemStore, PlanStore {
   private db: Database | null = null;
 
   constructor(private readonly dbPath: string) {}
@@ -41,6 +58,20 @@ export class SqliteWorkItemStore implements WorkItemStore {
         timestamp TEXT NOT NULL,
         trace_id TEXT NOT NULL,
         payload_json TEXT NOT NULL
+      );
+    `);
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS plans (
+        id TEXT PRIMARY KEY,
+        work_item_id TEXT NOT NULL,
+        intent_summary TEXT NOT NULL,
+        assumptions_json TEXT NOT NULL,
+        ambiguities_json TEXT NOT NULL,
+        proposed_next_step TEXT NOT NULL,
+        risk_level TEXT NOT NULL,
+        side_effects_json TEXT NOT NULL,
+        requires_approval INTEGER NOT NULL,
+        created_at TEXT NOT NULL
       );
     `);
     this.db = db;
@@ -90,6 +121,108 @@ export class SqliteWorkItemStore implements WorkItemStore {
       summary: row.summary,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+    };
+  }
+
+  async updateStatus(
+    id: string,
+    status: WorkItem["status"],
+    updatedAt: string,
+  ): Promise<void> {
+    this.ensureDb()
+      .query(
+        `
+          UPDATE work_items
+          SET status = $status, updated_at = $updated_at
+          WHERE id = $id
+        `,
+      )
+      .run({
+        id,
+        status,
+        updated_at: updatedAt,
+      });
+  }
+
+  async createPlan(plan: ExecutionPlan): Promise<void> {
+    this.ensureDb()
+      .query(
+        `
+          INSERT INTO plans (
+            id,
+            work_item_id,
+            intent_summary,
+            assumptions_json,
+            ambiguities_json,
+            proposed_next_step,
+            risk_level,
+            side_effects_json,
+            requires_approval,
+            created_at
+          ) VALUES (
+            $id,
+            $work_item_id,
+            $intent_summary,
+            $assumptions_json,
+            $ambiguities_json,
+            $proposed_next_step,
+            $risk_level,
+            $side_effects_json,
+            $requires_approval,
+            $created_at
+          )
+        `,
+      )
+      .run({
+        id: plan.id,
+        work_item_id: plan.workItemId,
+        intent_summary: plan.intentSummary,
+        assumptions_json: JSON.stringify(plan.assumptions),
+        ambiguities_json: JSON.stringify(plan.ambiguities),
+        proposed_next_step: plan.proposedNextStep,
+        risk_level: plan.riskLevel,
+        side_effects_json: JSON.stringify(plan.sideEffects),
+        requires_approval: plan.requiresApproval ? 1 : 0,
+        created_at: plan.createdAt,
+      });
+  }
+
+  async getPlanByWorkItemId(workItemId: string): Promise<ExecutionPlan | null> {
+    const row = this.ensureDb()
+      .query(
+        `
+          SELECT
+            id,
+            work_item_id,
+            intent_summary,
+            assumptions_json,
+            ambiguities_json,
+            proposed_next_step,
+            risk_level,
+            side_effects_json,
+            requires_approval,
+            created_at
+          FROM plans
+          WHERE work_item_id = $work_item_id
+        `,
+      )
+      .get({ work_item_id: workItemId }) as PlanRow | null;
+
+    if (!row) {
+      return null;
+    }
+
+    return {
+      id: row.id,
+      workItemId: row.work_item_id,
+      intentSummary: row.intent_summary,
+      assumptions: JSON.parse(row.assumptions_json) as string[],
+      ambiguities: JSON.parse(row.ambiguities_json) as string[],
+      proposedNextStep: row.proposed_next_step,
+      riskLevel: row.risk_level as ExecutionPlan["riskLevel"],
+      sideEffects: JSON.parse(row.side_effects_json) as PlanSideEffectType[],
+      requiresApproval: row.requires_approval === 1,
+      createdAt: row.created_at,
     };
   }
 

--- a/packages/adapters-telegram/package.json
+++ b/packages/adapters-telegram/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@delegate/adapters-telegram",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@delegate/domain": "workspace:*",
+    "@delegate/ports": "workspace:*"
+  }
+}

--- a/packages/adapters-telegram/src/index.ts
+++ b/packages/adapters-telegram/src/index.ts
@@ -1,0 +1,114 @@
+import type { InboundMessage, OutboundMessage } from "@delegate/domain";
+import type { ChatPort, ChatUpdate } from "@delegate/ports";
+
+type TelegramGetUpdatesResponse = {
+  ok: boolean;
+  result: Array<{
+    update_id: number;
+    message?: {
+      message_id: number;
+      date: number;
+      text?: string;
+      chat: {
+        id: number;
+      };
+    };
+  }>;
+};
+
+type TelegramSendMessageResponse = {
+  ok: boolean;
+};
+
+export class TelegramLongPollingAdapter implements ChatPort {
+  private readonly baseUrl: string;
+
+  constructor(private readonly botToken: string) {
+    this.baseUrl = `https://api.telegram.org/bot${botToken}`;
+  }
+
+  async receiveUpdates(cursor: number | null): Promise<ChatUpdate[]> {
+    const payload = {
+      timeout: 20,
+      allowed_updates: ["message"],
+      ...(cursor === null ? {} : { offset: cursor }),
+    };
+
+    const response = await fetch(`${this.baseUrl}/getUpdates`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Telegram getUpdates failed: ${response.status}`);
+    }
+
+    const decoded = (await response.json()) as TelegramGetUpdatesResponse;
+    if (!decoded.ok) {
+      throw new Error("Telegram getUpdates returned ok=false");
+    }
+
+    return decoded.result
+      .map((update) => {
+        const mapped = this.mapInbound(update.update_id, update.message);
+        if (!mapped) {
+          return null;
+        }
+        return {
+          updateId: update.update_id,
+          message: mapped,
+        } satisfies ChatUpdate;
+      })
+      .filter((entry): entry is ChatUpdate => entry !== null);
+  }
+
+  async send(message: OutboundMessage): Promise<void> {
+    const response = await fetch(`${this.baseUrl}/sendMessage`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        chat_id: message.chatId,
+        text: message.text,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Telegram sendMessage failed: ${response.status}`);
+    }
+
+    const decoded = (await response.json()) as TelegramSendMessageResponse;
+    if (!decoded.ok) {
+      throw new Error("Telegram sendMessage returned ok=false");
+    }
+  }
+
+  private mapInbound(
+    updateId: number,
+    rawMessage:
+      | {
+          message_id: number;
+          date: number;
+          text?: string;
+          chat: {
+            id: number;
+          };
+        }
+      | undefined,
+  ): InboundMessage | null {
+    if (!rawMessage?.text) {
+      return null;
+    }
+
+    return {
+      chatId: String(rawMessage.chat.id),
+      text: rawMessage.text.trim(),
+      receivedAt: new Date(rawMessage.date * 1000).toISOString(),
+      sourceMessageId: `${updateId}:${rawMessage.message_id}`,
+    };
+  }
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -9,7 +9,45 @@ export type WorkItem = {
   updatedAt: string;
 };
 
-export type AuditEventType = "work_item.delegated";
+export type PlanRiskLevel = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+
+export type PlanSideEffectType =
+  | "none"
+  | "local_code_changes"
+  | "external_publish";
+
+export type ExecutionPlanDraft = {
+  intentSummary: string;
+  assumptions: string[];
+  ambiguities: string[];
+  proposedNextStep: string;
+  riskLevel: PlanRiskLevel;
+  sideEffects: PlanSideEffectType[];
+  requiresApproval: boolean;
+};
+
+export type ExecutionPlan = {
+  id: string;
+  workItemId: string;
+  createdAt: string;
+} & ExecutionPlanDraft;
+
+export type InboundMessage = {
+  chatId: string;
+  text: string;
+  receivedAt: string;
+  sourceMessageId?: string;
+};
+
+export type OutboundMessage = {
+  chatId: string;
+  text: string;
+};
+
+export type AuditEventType =
+  | "work_item.delegated"
+  | "work_item.triaged"
+  | "plan.created";
 
 export type AuditEvent = {
   eventId: string;

--- a/packages/ports/src/index.ts
+++ b/packages/ports/src/index.ts
@@ -1,14 +1,51 @@
-import type { AuditEvent, WorkItem } from "@delegate/domain";
+import type {
+  AuditEvent,
+  ExecutionPlan,
+  ExecutionPlanDraft,
+  InboundMessage,
+  OutboundMessage,
+  WorkItem,
+  WorkItemStatus,
+} from "@delegate/domain";
 
 export interface WorkItemStore {
   init(): Promise<void>;
   ping(): Promise<void>;
   create(workItem: WorkItem): Promise<void>;
   getById(id: string): Promise<WorkItem | null>;
+  updateStatus(
+    id: string,
+    status: WorkItemStatus,
+    updatedAt: string,
+  ): Promise<void>;
+}
+
+export interface PlanStore {
+  createPlan(plan: ExecutionPlan): Promise<void>;
+  getPlanByWorkItemId(workItemId: string): Promise<ExecutionPlan | null>;
 }
 
 export interface AuditPort {
   init(): Promise<void>;
   ping(): Promise<void>;
   append(event: AuditEvent): Promise<void>;
+}
+
+export type ChatUpdate = {
+  updateId: number;
+  message: InboundMessage;
+};
+
+export interface ChatPort {
+  receiveUpdates(cursor: number | null): Promise<ChatUpdate[]>;
+  send(message: OutboundMessage): Promise<void>;
+}
+
+export type PlanInput = {
+  workItemId: string;
+  text: string;
+};
+
+export interface ModelPort {
+  plan(input: PlanInput): Promise<ExecutionPlanDraft>;
 }


### PR DESCRIPTION
Add real Telegram long polling, deterministic planning stub, persisted execution plans, and command routing placeholders so delegated requests return structured next steps while approval integrity is deferred to M3.

## Summary
- Describe what changed and why.

## Validation
- [x] `bun run verify`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run build`
- [x] `bun run test`
- [x] `bun run docs:check`

## Safety
- [ ] No secrets or credentials added
- [ ] Scope is focused and reviewable
