### PR TITLE
implement m3 policy and approval integrity

### DIFF
--- a/apps/assistant-core/package.json
+++ b/apps/assistant-core/package.json
@@ -14,6 +14,7 @@
     "@delegate/adapters-telegram": "workspace:*",
     "@delegate/audit": "workspace:*",
     "@delegate/domain": "workspace:*",
+    "@delegate/policy": "workspace:*",
     "@delegate/ports": "workspace:*",
     "effect": "^3.17.14"
   }

--- a/apps/assistant-core/src/main.ts
+++ b/apps/assistant-core/src/main.ts
@@ -2,6 +2,7 @@ import { DeterministicModelStub } from "@delegate/adapters-model-stub";
 import { SqliteWorkItemStore } from "@delegate/adapters-sqlite";
 import { TelegramLongPollingAdapter } from "@delegate/adapters-telegram";
 import { JsonlAuditPort } from "@delegate/audit";
+import { DefaultPolicyEngine } from "@delegate/policy";
 import { Effect } from "effect";
 
 import { loadConfig } from "./config";
@@ -13,6 +14,7 @@ const config = loadConfig();
 const workItemStore = new SqliteWorkItemStore(config.sqlitePath);
 const auditPort = new JsonlAuditPort(config.auditLogPath);
 const modelPort = new DeterministicModelStub();
+const policyEngine = new DefaultPolicyEngine();
 
 const boot = Effect.gen(function* () {
   yield* Effect.tryPromise({
@@ -43,6 +45,8 @@ const boot = Effect.gen(function* () {
         modelPort,
         workItemStore,
         planStore: workItemStore,
+        approvalStore: workItemStore,
+        policyEngine,
         auditPort,
       },
       config.telegramPollIntervalMs,

--- a/apps/assistant-core/src/worker.test.ts
+++ b/apps/assistant-core/src/worker.test.ts
@@ -1,21 +1,26 @@
 import { describe, expect, test } from "bun:test";
 
 import type {
+  ApprovalRecord,
+  ApprovalStatus,
   AuditEvent,
   ExecutionPlan,
   ExecutionPlanDraft,
   InboundMessage,
   OutboundMessage,
+  PolicyDecision,
   WorkItem,
   WorkItemStatus,
 } from "@delegate/domain";
 import type {
+  ApprovalStore,
   AuditPort,
   ChatPort,
   ChatUpdate,
   ModelPort,
   PlanInput,
   PlanStore,
+  PolicyEngine,
   WorkItemStore,
 } from "@delegate/ports";
 
@@ -69,6 +74,78 @@ class InMemoryPlanStore implements PlanStore {
   }
 }
 
+class InMemoryApprovalStore implements ApprovalStore {
+  private readonly approvals = new Map<string, ApprovalRecord>();
+
+  async createApproval(record: ApprovalRecord): Promise<void> {
+    this.approvals.set(record.id, record);
+  }
+
+  async getApprovalById(approvalId: string): Promise<ApprovalRecord | null> {
+    return this.approvals.get(approvalId) ?? null;
+  }
+
+  async getLatestApprovalByWorkItemId(
+    workItemId: string,
+  ): Promise<ApprovalRecord | null> {
+    const values = [...this.approvals.values()].filter(
+      (approval) => approval.workItemId === workItemId,
+    );
+    values.sort((a, b) =>
+      a.requestedAt < b.requestedAt
+        ? 1
+        : a.requestedAt > b.requestedAt
+          ? -1
+          : 0,
+    );
+    return values[0] ?? null;
+  }
+
+  async updateApprovalStatus(
+    approvalId: string,
+    status: ApprovalStatus,
+    consumedAt: string | null,
+    decisionReason: string | null,
+  ): Promise<void> {
+    const existing = this.approvals.get(approvalId);
+    if (!existing) {
+      return;
+    }
+    this.approvals.set(approvalId, {
+      ...existing,
+      status,
+      consumedAt,
+      decisionReason,
+    });
+  }
+
+  all(): ApprovalRecord[] {
+    return [...this.approvals.values()];
+  }
+
+  tamperPayloadHash(approvalId: string, payloadHash: string): void {
+    const existing = this.approvals.get(approvalId);
+    if (!existing) {
+      return;
+    }
+    this.approvals.set(approvalId, {
+      ...existing,
+      payloadHash,
+    });
+  }
+
+  tamperExpiry(approvalId: string, expiresAt: string): void {
+    const existing = this.approvals.get(approvalId);
+    if (!existing) {
+      return;
+    }
+    this.approvals.set(approvalId, {
+      ...existing,
+      expiresAt,
+    });
+  }
+}
+
 class CapturingChatPort implements ChatPort {
   readonly sent: OutboundMessage[] = [];
 
@@ -107,11 +184,45 @@ class HighRiskModelStub implements ModelPort {
   }
 }
 
+class ApprovalRequiredPolicy implements PolicyEngine {
+  async evaluate(_plan: ExecutionPlanDraft): Promise<PolicyDecision> {
+    return {
+      decision: "requires_approval",
+      reasonCode: "MISSING_APPROVAL",
+    };
+  }
+}
+
 const inbound = (text: string): InboundMessage => ({
   chatId: "123",
   text,
   receivedAt: new Date().toISOString(),
 });
+
+const setup = () => {
+  const workItemStore = new InMemoryWorkItemStore();
+  const planStore = new InMemoryPlanStore();
+  const approvalStore = new InMemoryApprovalStore();
+  const chatPort = new CapturingChatPort();
+  const auditPort = new CapturingAuditPort();
+
+  return {
+    deps: {
+      chatPort,
+      modelPort: new HighRiskModelStub(),
+      workItemStore,
+      planStore,
+      approvalStore,
+      policyEngine: new ApprovalRequiredPolicy(),
+      auditPort,
+    },
+    workItemStore,
+    planStore,
+    approvalStore,
+    chatPort,
+    auditPort,
+  };
+};
 
 describe("parseCommand", () => {
   test("parses slash commands", () => {
@@ -130,62 +241,108 @@ describe("parseCommand", () => {
 });
 
 describe("handleChatMessage", () => {
-  test("creates work item, persists plan, and responds with preview", async () => {
-    const workItemStore = new InMemoryWorkItemStore();
-    const planStore = new InMemoryPlanStore();
-    const chatPort = new CapturingChatPort();
-    const auditPort = new CapturingAuditPort();
+  test("creates approval-pending work item and returns approval id", async () => {
+    const state = setup();
 
     await handleChatMessage(
-      {
-        chatPort,
-        modelPort: new HighRiskModelStub(),
-        workItemStore,
-        planStore,
-        auditPort,
-      },
+      state.deps,
       inbound("Please publish a PR for this refactor"),
     );
 
-    const items = workItemStore.all();
+    const items = state.workItemStore.all();
     expect(items.length).toBe(1);
-    expect(items[0]?.status).toBe("triaged");
+    expect(items[0]?.status).toBe("approval_pending");
 
-    const plan = await planStore.getPlanByWorkItemId(items[0]!.id);
-    expect(plan?.requiresApproval).toBe(true);
-    expect(chatPort.sent[0]?.text.includes("Approval preview")).toBe(true);
-    expect(auditPort.events.map((event) => event.eventType)).toEqual([
+    const approval = state.approvalStore.all()[0];
+    expect(approval?.status).toBe("pending");
+    expect(state.chatPort.sent[0]?.text).toContain(`/approve ${approval?.id}`);
+    expect(state.auditPort.events.map((event) => event.eventType)).toEqual([
       "work_item.delegated",
+      "approval.requested",
       "plan.created",
       "work_item.triaged",
     ]);
   });
 
-  test("returns status for existing work item", async () => {
-    const workItemStore = new InMemoryWorkItemStore();
-    const planStore = new InMemoryPlanStore();
-    const chatPort = new CapturingChatPort();
-
-    await workItemStore.create({
-      id: "work-123",
-      traceId: "trace-123",
-      status: "triaged",
-      summary: "A task",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+  test("returns approval status in status command", async () => {
+    const state = setup();
 
     await handleChatMessage(
-      {
-        chatPort,
-        modelPort: new HighRiskModelStub(),
-        workItemStore,
-        planStore,
-        auditPort: new CapturingAuditPort(),
-      },
-      inbound("/status work-123"),
+      state.deps,
+      inbound("Please publish a PR for this refactor"),
     );
 
-    expect(chatPort.sent[0]?.text).toContain("status=triaged");
+    const workItemId = state.workItemStore.all()[0]!.id;
+    await handleChatMessage(state.deps, inbound(`/status ${workItemId}`));
+
+    expect(state.chatPort.sent[1]?.text).toContain("approval=pending");
+  });
+
+  test("approves once and rejects replay", async () => {
+    const state = setup();
+
+    await handleChatMessage(
+      state.deps,
+      inbound("Please publish a PR for this refactor"),
+    );
+
+    const approvalId = state.approvalStore.all()[0]!.id;
+    await handleChatMessage(state.deps, inbound(`/approve ${approvalId}`));
+    await handleChatMessage(state.deps, inbound(`/approve ${approvalId}`));
+
+    expect(state.chatPort.sent[1]?.text).toContain("Approval accepted");
+    expect(state.chatPort.sent[2]?.text).toContain(
+      "Approval rejected: REPLAYED",
+    );
+  });
+
+  test("denies and marks work item denied", async () => {
+    const state = setup();
+
+    await handleChatMessage(
+      state.deps,
+      inbound("Please publish a PR for this refactor"),
+    );
+
+    const approvalId = state.approvalStore.all()[0]!.id;
+    await handleChatMessage(state.deps, inbound(`/deny ${approvalId}`));
+
+    const item = state.workItemStore.all()[0]!;
+    expect(item.status).toBe("denied");
+    expect(state.chatPort.sent[1]?.text).toContain("Approval denied");
+  });
+
+  test("rejects expired approvals", async () => {
+    const state = setup();
+
+    await handleChatMessage(
+      state.deps,
+      inbound("Please publish a PR for this refactor"),
+    );
+
+    const approvalId = state.approvalStore.all()[0]!.id;
+    state.approvalStore.tamperExpiry(approvalId, "2000-01-01T00:00:00.000Z");
+
+    await handleChatMessage(state.deps, inbound(`/approve ${approvalId}`));
+    expect(state.chatPort.sent[1]?.text).toContain(
+      "Approval rejected: EXPIRED",
+    );
+  });
+
+  test("rejects mismatched approval hash", async () => {
+    const state = setup();
+
+    await handleChatMessage(
+      state.deps,
+      inbound("Please publish a PR for this refactor"),
+    );
+
+    const approvalId = state.approvalStore.all()[0]!.id;
+    state.approvalStore.tamperPayloadHash(approvalId, "tampered");
+
+    await handleChatMessage(state.deps, inbound(`/approve ${approvalId}`));
+    expect(state.chatPort.sent[1]?.text).toContain(
+      "Approval rejected: MISMATCH",
+    );
   });
 });

--- a/apps/assistant-core/src/worker.ts
+++ b/apps/assistant-core/src/worker.ts
@@ -1,14 +1,18 @@
 import type {
+  ApprovalRecord,
   AuditEvent,
   ExecutionPlan,
   InboundMessage,
+  PolicyDecision,
   WorkItem,
 } from "@delegate/domain";
 import type {
+  ApprovalStore,
   AuditPort,
   ChatPort,
   ModelPort,
   PlanStore,
+  PolicyEngine,
   WorkItemStore,
 } from "@delegate/ports";
 
@@ -31,7 +35,61 @@ type WorkerDeps = {
   modelPort: ModelPort;
   workItemStore: WorkItemStore;
   planStore: PlanStore;
+  approvalStore: ApprovalStore;
+  policyEngine: PolicyEngine;
   auditPort: AuditPort;
+};
+
+type LogFields = Record<string, string | number | boolean | null>;
+
+const logInfo = (event: string, fields: LogFields = {}): void => {
+  console.log(
+    JSON.stringify({
+      level: "info",
+      event,
+      ...fields,
+    }),
+  );
+};
+
+const logError = (event: string, fields: LogFields = {}): void => {
+  console.error(
+    JSON.stringify({
+      level: "error",
+      event,
+      ...fields,
+    }),
+  );
+};
+
+const toSha256Hex = async (input: string): Promise<string> => {
+  const encoded = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", encoded);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+const approvalActionType = "publish_pr" as const;
+
+const addHours = (iso: string, hours: number): string => {
+  const value = new Date(iso).getTime() + hours * 60 * 60 * 1000;
+  return new Date(value).toISOString();
+};
+
+const isExpired = (expiryIso: string, now: string): boolean =>
+  new Date(expiryIso).getTime() <= new Date(now).getTime();
+
+const approvalPayloadHash = async (plan: ExecutionPlan): Promise<string> => {
+  const canonical = JSON.stringify({
+    actionType: approvalActionType,
+    workItemId: plan.workItemId,
+    intentSummary: plan.intentSummary,
+    proposedNextStep: plan.proposedNextStep,
+    riskLevel: plan.riskLevel,
+    sideEffects: [...plan.sideEffects].sort(),
+  });
+  return toSha256Hex(canonical);
 };
 
 export const parseCommand = (text: string): Command => {
@@ -68,6 +126,7 @@ const summarize = (text: string): string => {
 const formatPlanResponse = (
   workItem: WorkItem,
   plan: ExecutionPlan,
+  approval: ApprovalRecord | null,
 ): string => {
   const lines = [
     `Work item ${workItem.id}`,
@@ -77,10 +136,11 @@ const formatPlanResponse = (
     `Next: ${plan.proposedNextStep}`,
   ];
 
-  if (plan.requiresApproval) {
+  if (approval) {
     lines.push(
-      `Approval preview: risk ${plan.riskLevel}; side effects ${plan.sideEffects.join(", ")}; would expire in 24h (enforced in M3).`,
+      `Approval required: /approve ${approval.id} (risk ${plan.riskLevel}; side effects ${plan.sideEffects.join(", ")}; expires ${approval.expiresAt}).`,
     );
+    lines.push(`To deny: /deny ${approval.id}`);
   }
 
   lines.push(`Check progress: /status ${workItem.id}`);
@@ -94,67 +154,367 @@ const appendAuditEvent = async (
   await auditPort.append(event);
 };
 
+const sendMessage = async (
+  chatPort: ChatPort,
+  outbound: { chatId: string; text: string },
+  fields: LogFields,
+): Promise<void> => {
+  await chatPort.send(outbound);
+  logInfo("chat.message.sent", {
+    chatId: outbound.chatId,
+    chars: outbound.text.length,
+    ...fields,
+  });
+};
+
+const appendApprovalRejectedAudit = async (
+  deps: WorkerDeps,
+  approval: ApprovalRecord,
+  reason: string,
+): Promise<void> => {
+  const traceId =
+    (await deps.workItemStore.getById(approval.workItemId))?.traceId ??
+    "unknown";
+  await appendAuditEvent(deps.auditPort, {
+    eventId: crypto.randomUUID(),
+    eventType: "approval.rejected",
+    workItemId: approval.workItemId,
+    actor: "system",
+    timestamp: nowIso(),
+    traceId,
+    payload: {
+      approvalId: approval.id,
+      reason,
+    },
+  });
+};
+
+const handleStatusCommand = async (
+  deps: WorkerDeps,
+  message: InboundMessage,
+  workItemId: string | null,
+): Promise<void> => {
+  if (!workItemId) {
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: "Usage: /status <workItemId>",
+      },
+      { command: "status" },
+    );
+    return;
+  }
+
+  const workItem = await deps.workItemStore.getById(workItemId);
+  if (!workItem) {
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: `No work item found for id ${workItemId}.`,
+      },
+      { command: "status", workItemId },
+    );
+    return;
+  }
+
+  const plan = await deps.planStore.getPlanByWorkItemId(workItemId);
+  const approval =
+    await deps.approvalStore.getLatestApprovalByWorkItemId(workItemId);
+  const approvalText = approval
+    ? `; approval=${approval.status}${approval.status === "pending" ? `(${approval.id})` : ""}`
+    : "";
+
+  await sendMessage(
+    deps.chatPort,
+    {
+      chatId: message.chatId,
+      text: `Work item ${workItem.id}: status=${workItem.status}; plan=${plan ? "ready" : "pending"}${approvalText}`,
+    },
+    { command: "status", workItemId },
+  );
+};
+
+const resolvePlanByApproval = async (
+  deps: WorkerDeps,
+  approval: ApprovalRecord,
+): Promise<ExecutionPlan | null> =>
+  deps.planStore.getPlanByWorkItemId(approval.workItemId);
+
+const handleApproveCommand = async (
+  deps: WorkerDeps,
+  message: InboundMessage,
+  approvalId: string | null,
+): Promise<void> => {
+  if (!approvalId) {
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: "Usage: /approve <approvalId>",
+      },
+      { command: "approve" },
+    );
+    return;
+  }
+
+  const approval = await deps.approvalStore.getApprovalById(approvalId);
+  if (!approval) {
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: `Approval rejected: NOT_FOUND for ${approvalId}.`,
+      },
+      { command: "approve", approvalId, reason: "NOT_FOUND" },
+    );
+    return;
+  }
+
+  if (approval.status === "denied") {
+    await appendApprovalRejectedAudit(deps, approval, "ALREADY_DENIED");
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: `Approval rejected: ALREADY_DENIED for ${approvalId}.`,
+      },
+      { command: "approve", approvalId, reason: "ALREADY_DENIED" },
+    );
+    return;
+  }
+
+  if (approval.status !== "pending") {
+    await appendApprovalRejectedAudit(deps, approval, "REPLAYED");
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: `Approval rejected: REPLAYED for ${approvalId}.`,
+      },
+      { command: "approve", approvalId, reason: "REPLAYED" },
+    );
+    return;
+  }
+
+  const now = nowIso();
+  if (isExpired(approval.expiresAt, now)) {
+    await deps.approvalStore.updateApprovalStatus(
+      approval.id,
+      "expired",
+      now,
+      "EXPIRED",
+    );
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: `Approval rejected: EXPIRED for ${approvalId}.`,
+      },
+      { command: "approve", approvalId, reason: "EXPIRED" },
+    );
+    await appendApprovalRejectedAudit(deps, approval, "EXPIRED");
+    return;
+  }
+
+  const plan = await resolvePlanByApproval(deps, approval);
+  if (!plan) {
+    await appendApprovalRejectedAudit(deps, approval, "MISMATCH");
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: `Approval rejected: MISMATCH for ${approvalId}.`,
+      },
+      { command: "approve", approvalId, reason: "MISMATCH" },
+    );
+    return;
+  }
+
+  const hash = await approvalPayloadHash(plan);
+  if (hash !== approval.payloadHash) {
+    await appendApprovalRejectedAudit(deps, approval, "MISMATCH");
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: `Approval rejected: MISMATCH for ${approvalId}.`,
+      },
+      {
+        command: "approve",
+        approvalId,
+        reason: "MISMATCH",
+        workItemId: approval.workItemId,
+      },
+    );
+    return;
+  }
+
+  await deps.approvalStore.updateApprovalStatus(
+    approval.id,
+    "approved",
+    now,
+    "APPROVED",
+  );
+  await deps.workItemStore.updateStatus(approval.workItemId, "approved", now);
+  const traceId =
+    (await deps.workItemStore.getById(approval.workItemId))?.traceId ??
+    "unknown";
+
+  await appendAuditEvent(deps.auditPort, {
+    eventId: crypto.randomUUID(),
+    eventType: "approval.granted",
+    workItemId: approval.workItemId,
+    actor: "user",
+    timestamp: now,
+    traceId,
+    payload: {
+      approvalId: approval.id,
+      actionType: approval.actionType,
+    },
+  });
+
+  await sendMessage(
+    deps.chatPort,
+    {
+      chatId: message.chatId,
+      text: `Approval accepted for work item ${approval.workItemId}. Execution remains gated until M4 publish path is implemented.`,
+    },
+    { command: "approve", approvalId, workItemId: approval.workItemId },
+  );
+};
+
+const handleDenyCommand = async (
+  deps: WorkerDeps,
+  message: InboundMessage,
+  approvalId: string | null,
+): Promise<void> => {
+  if (!approvalId) {
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: "Usage: /deny <approvalId>",
+      },
+      { command: "deny" },
+    );
+    return;
+  }
+
+  const approval = await deps.approvalStore.getApprovalById(approvalId);
+  if (!approval) {
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: `Denial rejected: NOT_FOUND for ${approvalId}.`,
+      },
+      { command: "deny", approvalId, reason: "NOT_FOUND" },
+    );
+    return;
+  }
+
+  if (approval.status !== "pending") {
+    await appendApprovalRejectedAudit(deps, approval, "REPLAYED");
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: `Denial rejected: REPLAYED for ${approvalId}.`,
+      },
+      { command: "deny", approvalId, reason: "REPLAYED" },
+    );
+    return;
+  }
+
+  const now = nowIso();
+  await deps.approvalStore.updateApprovalStatus(
+    approval.id,
+    "denied",
+    now,
+    "USER_DENIED",
+  );
+  await deps.workItemStore.updateStatus(approval.workItemId, "denied", now);
+  const traceId =
+    (await deps.workItemStore.getById(approval.workItemId))?.traceId ??
+    "unknown";
+
+  await appendAuditEvent(deps.auditPort, {
+    eventId: crypto.randomUUID(),
+    eventType: "approval.denied",
+    workItemId: approval.workItemId,
+    actor: "user",
+    timestamp: now,
+    traceId,
+    payload: {
+      approvalId: approval.id,
+      actionType: approval.actionType,
+    },
+  });
+
+  await sendMessage(
+    deps.chatPort,
+    {
+      chatId: message.chatId,
+      text: `Approval denied for work item ${approval.workItemId}. No external action will be executed.`,
+    },
+    { command: "deny", approvalId, workItemId: approval.workItemId },
+  );
+};
+
 export const handleChatMessage = async (
   deps: WorkerDeps,
   message: InboundMessage,
 ): Promise<void> => {
+  logInfo("chat.message.received", {
+    chatId: message.chatId,
+    sourceMessageId: message.sourceMessageId ?? null,
+    chars: message.text.length,
+  });
+
   const command = parseCommand(message.text);
+  logInfo("chat.command.parsed", {
+    chatId: message.chatId,
+    command: command.type,
+  });
 
   if (command.type === "status") {
-    if (!command.workItemId) {
-      await deps.chatPort.send({
-        chatId: message.chatId,
-        text: "Usage: /status <workItemId>",
-      });
-      return;
-    }
-
-    const workItem = await deps.workItemStore.getById(command.workItemId);
-    if (!workItem) {
-      await deps.chatPort.send({
-        chatId: message.chatId,
-        text: `No work item found for id ${command.workItemId}.`,
-      });
-      return;
-    }
-
-    const plan = await deps.planStore.getPlanByWorkItemId(command.workItemId);
-    await deps.chatPort.send({
-      chatId: message.chatId,
-      text: `Work item ${workItem.id}: status=${workItem.status}; plan=${plan ? "ready" : "pending"}`,
-    });
+    await handleStatusCommand(deps, message, command.workItemId);
     return;
   }
 
   if (command.type === "approve") {
-    await deps.chatPort.send({
-      chatId: message.chatId,
-      text: `Approval flow activates in M3. Received approval id: ${command.approvalId ?? "(missing)"}.`,
-    });
+    await handleApproveCommand(deps, message, command.approvalId);
     return;
   }
 
   if (command.type === "deny") {
-    await deps.chatPort.send({
-      chatId: message.chatId,
-      text: `Denial flow activates in M3. Received approval id: ${command.approvalId ?? "(missing)"}.`,
-    });
+    await handleDenyCommand(deps, message, command.approvalId);
     return;
   }
 
   if (command.type === "explain") {
-    await deps.chatPort.send({
-      chatId: message.chatId,
-      text: `Explain output activates in M5. For now use /status ${command.workItemId ?? "<workItemId>"}.`,
-    });
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: `Explain output activates in M5. For now use /status ${command.workItemId ?? "<workItemId>"}.`,
+      },
+      { command: "explain" },
+    );
     return;
   }
 
   if (!command.text) {
-    await deps.chatPort.send({
-      chatId: message.chatId,
-      text: "Please send a request with some detail.",
-    });
+    await sendMessage(
+      deps.chatPort,
+      {
+        chatId: message.chatId,
+        text: "Please send a request with some detail.",
+      },
+      { command: "delegate", validation: "empty_text" },
+    );
     return;
   }
 
@@ -169,6 +529,12 @@ export const handleChatMessage = async (
   };
 
   await deps.workItemStore.create(workItem);
+  logInfo("work_item.created", {
+    workItemId: workItem.id,
+    traceId: workItem.traceId,
+    status: workItem.status,
+  });
+
   await appendAuditEvent(deps.auditPort, {
     eventId: crypto.randomUUID(),
     eventType: "work_item.delegated",
@@ -187,6 +553,20 @@ export const handleChatMessage = async (
     workItemId: workItem.id,
     text: command.text,
   });
+  logInfo("plan.drafted", {
+    workItemId: workItem.id,
+    traceId: workItem.traceId,
+    riskLevel: draft.riskLevel,
+    requiresApproval: draft.requiresApproval,
+  });
+
+  const policy: PolicyDecision = await deps.policyEngine.evaluate(draft);
+  logInfo("policy.evaluated", {
+    workItemId: workItem.id,
+    traceId: workItem.traceId,
+    decision: policy.decision,
+    reasonCode: policy.reasonCode,
+  });
 
   const plan: ExecutionPlan = {
     id: crypto.randomUUID(),
@@ -196,7 +576,58 @@ export const handleChatMessage = async (
   };
 
   await deps.planStore.createPlan(plan);
-  await deps.workItemStore.updateStatus(workItem.id, "triaged", nowIso());
+  logInfo("plan.persisted", {
+    workItemId: workItem.id,
+    traceId: workItem.traceId,
+    planId: plan.id,
+  });
+
+  let nextStatus: WorkItem["status"] = "triaged";
+  let approvalRecord: ApprovalRecord | null = null;
+
+  if (policy.decision === "requires_approval") {
+    const requestedAt = nowIso();
+    approvalRecord = {
+      id: crypto.randomUUID(),
+      workItemId: workItem.id,
+      actionType: approvalActionType,
+      payloadHash: await approvalPayloadHash(plan),
+      status: "pending",
+      requestedAt,
+      expiresAt: addHours(requestedAt, 24),
+      consumedAt: null,
+      decisionReason: null,
+    };
+    await deps.approvalStore.createApproval(approvalRecord);
+    nextStatus = "approval_pending";
+    await appendAuditEvent(deps.auditPort, {
+      eventId: crypto.randomUUID(),
+      eventType: "approval.requested",
+      workItemId: workItem.id,
+      actor: "assistant",
+      timestamp: nowIso(),
+      traceId: workItem.traceId,
+      payload: {
+        approvalId: approvalRecord.id,
+        actionType: approvalRecord.actionType,
+        expiresAt: approvalRecord.expiresAt,
+        reasonCode: policy.reasonCode,
+      },
+    });
+    logInfo("approval.requested", {
+      workItemId: workItem.id,
+      traceId: workItem.traceId,
+      approvalId: approvalRecord.id,
+      expiresAt: approvalRecord.expiresAt,
+    });
+  }
+
+  await deps.workItemStore.updateStatus(workItem.id, nextStatus, nowIso());
+  logInfo("work_item.status_updated", {
+    workItemId: workItem.id,
+    traceId: workItem.traceId,
+    status: nextStatus,
+  });
 
   await appendAuditEvent(deps.auditPort, {
     eventId: crypto.randomUUID(),
@@ -208,7 +639,7 @@ export const handleChatMessage = async (
     payload: {
       planId: plan.id,
       riskLevel: plan.riskLevel,
-      requiresApproval: plan.requiresApproval,
+      requiresApproval: policy.decision === "requires_approval",
     },
   });
 
@@ -225,13 +656,23 @@ export const handleChatMessage = async (
     },
   });
 
-  await deps.chatPort.send({
-    chatId: message.chatId,
-    text: formatPlanResponse(
-      { ...workItem, status: "triaged", updatedAt: nowIso() },
-      plan,
-    ),
-  });
+  await sendMessage(
+    deps.chatPort,
+    {
+      chatId: message.chatId,
+      text: formatPlanResponse(
+        { ...workItem, status: nextStatus, updatedAt: nowIso() },
+        plan,
+        approvalRecord,
+      ),
+    },
+    {
+      workItemId: workItem.id,
+      traceId: workItem.traceId,
+      approvalId: approvalRecord?.id ?? null,
+      command: "delegate",
+    },
+  );
 };
 
 export const startTelegramWorker = (
@@ -244,12 +685,20 @@ export const startTelegramWorker = (
     while (true) {
       try {
         const updates = await deps.chatPort.receiveUpdates(cursor);
+        if (updates.length > 0) {
+          logInfo("chat.updates.received", {
+            count: updates.length,
+            cursor,
+          });
+        }
         for (const update of updates) {
           cursor = update.updateId + 1;
           await handleChatMessage(deps, update.message);
         }
       } catch (error) {
-        console.error("telegram worker cycle failed", error);
+        logError("worker.cycle.failed", {
+          error: String(error),
+        });
       }
 
       await sleep(pollIntervalMs);

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "@delegate/adapters-telegram": "workspace:*",
         "@delegate/audit": "workspace:*",
         "@delegate/domain": "workspace:*",
+        "@delegate/policy": "workspace:*",
         "@delegate/ports": "workspace:*",
         "effect": "^3.17.14",
       },
@@ -56,6 +57,13 @@
     },
     "packages/domain": {
       "name": "@delegate/domain",
+    },
+    "packages/policy": {
+      "name": "@delegate/policy",
+      "dependencies": {
+        "@delegate/domain": "workspace:*",
+        "@delegate/ports": "workspace:*",
+      },
     },
     "packages/ports": {
       "name": "@delegate/ports",
@@ -98,6 +106,8 @@
     "@delegate/audit": ["@delegate/audit@workspace:packages/audit"],
 
     "@delegate/domain": ["@delegate/domain@workspace:packages/domain"],
+
+    "@delegate/policy": ["@delegate/policy@workspace:packages/policy"],
 
     "@delegate/ports": ["@delegate/ports@workspace:packages/ports"],
 

--- a/docs/00-09_meta/00-index.md
+++ b/docs/00-09_meta/00-index.md
@@ -5,7 +5,8 @@ Knowledge Index (Johnny Decimal)
 ## Current v0 Status
 - M1 Foundation Tracer Bullet: complete
 - M2 Telegram Delegation + Planning: complete
-- M3 Policy + Approval Integrity: next
+- M3 Policy + Approval Integrity: complete
+- M4 Approval-Gated GitHub PR Publish: next
 - CI quality gate is active: `bun run verify`
 
 ## 00-09 Meta

--- a/docs/30-39_execution/30-v0-working-plan.md
+++ b/docs/30-39_execution/30-v0-working-plan.md
@@ -8,8 +8,8 @@ Provide an execution-first plan for delivering v0 in small vertical slices with 
 ## Milestone Status
 - M1 Foundation Tracer Bullet: complete
 - M2 Telegram Delegation + Planning: complete
-- M3 Policy + Approval Integrity: next
-- M4 Approval-Gated GitHub PR Publish: not started
+- M3 Policy + Approval Integrity: complete
+- M4 Approval-Gated GitHub PR Publish: next
 - M5 Explainability, Recovery, and Test Matrix: not started
 
 ## Non-Goals (v0)
@@ -114,6 +114,12 @@ Template:
 - Decisions:
 - Files changed:
 - Blockers/notes:
+
+2026-02-07
+- Completed: M3 policy and approval integrity with approval requests, one-time approval consumption, expiry and payload-hash checks, denial terminal behavior, and structured lifecycle logs.
+- Decisions: Added `@delegate/policy` as a default policy engine package; retained strict orchestrator gate for `/approve` and `/deny`; kept execution message explicit that publish remains gated until M4.
+- Files changed: `apps/assistant-core/src/main.ts`, `apps/assistant-core/src/worker.ts`, `apps/assistant-core/src/worker.test.ts`, `apps/assistant-core/package.json`, `packages/domain/src/index.ts`, `packages/ports/src/index.ts`, `packages/policy/package.json`, `packages/policy/src/index.ts`, `packages/adapters-sqlite/src/index.ts`, `packages/adapters-sqlite/src/index.test.ts`, `docs/00-09_meta/00-index.md`, `docs/30-39_execution/30-v0-working-plan.md`, `bun.lock`.
+- Blockers/notes: Live worker logs now stream JSON lines to stdout and include correlation ids (`workItemId`, `traceId`, `approvalId`).
 
 2026-02-07
 - Completed: M2 Telegram delegation + planning slice with real Telegram long polling adapter, deterministic planner stub, persisted plans, command router, and status responses.

--- a/docs/30-39_execution/31-v0-implementation-blueprint.md
+++ b/docs/30-39_execution/31-v0-implementation-blueprint.md
@@ -12,6 +12,8 @@ This document defines the concrete build plan, package layout, and implementatio
 - Quality gates are centralized under `bun run verify` and enforced in CI.
 - M2 is implemented with real Telegram long polling and a deterministic `ModelPort.plan` stub; real OpenAI integration is deferred.
 - M2 command behavior: `/status` is active, while `/approve` and `/deny` are explicit placeholders until M3 approval integrity is wired.
+- M3 implements policy decisions plus approval integrity checks (one-time consumption, expiry, payload-hash validation) with auditable approval events.
+- M3 adds structured JSON lifecycle logs to stdout for live operator visibility with correlation IDs.
 
 ## 1. Monorepo Layout
 

--- a/packages/policy/package.json
+++ b/packages/policy/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@delegate/policy",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@delegate/domain": "workspace:*",
+    "@delegate/ports": "workspace:*"
+  }
+}

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -1,0 +1,22 @@
+import type { ExecutionPlanDraft, PolicyDecision } from "@delegate/domain";
+import type { PolicyEngine } from "@delegate/ports";
+
+export class DefaultPolicyEngine implements PolicyEngine {
+  async evaluate(plan: ExecutionPlanDraft): Promise<PolicyDecision> {
+    if (
+      plan.requiresApproval ||
+      plan.riskLevel === "HIGH" ||
+      plan.riskLevel === "CRITICAL"
+    ) {
+      return {
+        decision: "requires_approval",
+        reasonCode: "MISSING_APPROVAL",
+      };
+    }
+
+    return {
+      decision: "allow",
+      reasonCode: "LOW_RISK_ALLOWED",
+    };
+  }
+}

--- a/packages/ports/src/index.ts
+++ b/packages/ports/src/index.ts
@@ -1,9 +1,13 @@
 import type {
+  ApprovalRecord,
+  ApprovalRejectReason,
+  ApprovalStatus,
   AuditEvent,
   ExecutionPlan,
   ExecutionPlanDraft,
   InboundMessage,
   OutboundMessage,
+  PolicyDecision,
   WorkItem,
   WorkItemStatus,
 } from "@delegate/domain";
@@ -23,6 +27,20 @@ export interface WorkItemStore {
 export interface PlanStore {
   createPlan(plan: ExecutionPlan): Promise<void>;
   getPlanByWorkItemId(workItemId: string): Promise<ExecutionPlan | null>;
+}
+
+export interface ApprovalStore {
+  createApproval(record: ApprovalRecord): Promise<void>;
+  getApprovalById(approvalId: string): Promise<ApprovalRecord | null>;
+  getLatestApprovalByWorkItemId(
+    workItemId: string,
+  ): Promise<ApprovalRecord | null>;
+  updateApprovalStatus(
+    approvalId: string,
+    status: ApprovalStatus,
+    consumedAt: string | null,
+    decisionReason: string | null,
+  ): Promise<void>;
 }
 
 export interface AuditPort {
@@ -49,3 +67,11 @@ export type PlanInput = {
 export interface ModelPort {
   plan(input: PlanInput): Promise<ExecutionPlanDraft>;
 }
+
+export interface PolicyEngine {
+  evaluate(plan: ExecutionPlanDraft): Promise<PolicyDecision>;
+}
+
+export type ApprovalValidationResult =
+  | { ok: true; approval: ApprovalRecord }
+  | { ok: false; reason: ApprovalRejectReason };


### PR DESCRIPTION
## Summary
- Implement M3 policy and approval integrity end-to-end: add policy evaluation, approval persistence, and enforced `/approve` and `/deny` flows with expiry, replay, and payload-hash mismatch rejection.
- Add structured JSON lifecycle logs with correlation ids so Telegram processing and approval decisions are visible in real time.
- Update status/docs to mark M3 complete and advance M4 as next milestone.

## Validation
- `bun run verify`