### PR TITLE
add per-topic workspace switching with deterministic intents

### DIFF
--- a/apps/assistant-core/src/main.ts
+++ b/apps/assistant-core/src/main.ts
@@ -65,6 +65,7 @@ const boot = async () => {
         progressFirstMs: config.progressFirstMs,
         progressEveryMs: config.progressEveryMs,
         progressMaxCount: config.progressMaxCount,
+        defaultWorkspacePath: config.assistantRepoPath,
       },
     );
   } else {

--- a/docs/00-09_meta/00-index.md
+++ b/docs/00-09_meta/00-index.md
@@ -6,9 +6,15 @@ Knowledge Index (Johnny Decimal)
 - Telegram <-> OpenCode relay runtime: active
 - Topic-aware session continuity (`chatId:threadId`): active
 - Persistent session/cursor store: active
+- Topic workspace switching with per-workspace session continuity: active
 - OpenCode auto-start (`opencode serve`) + attach flow: active
 - Minimal ops surface (`/health`, `/ready`): active
 - CI quality gate is active: `bun run verify`
+
+## Planned Next Capability
+- Email delegation via forwarded content: summary + draft replies in Telegram
+- Approval-gated email sending as a follow-up slice
+- Canonical feature sequencing is tracked in `docs/30-39_execution/30-v0-working-plan.md`
 
 ## Active Runtime Surface
 - `apps/assistant-core/src/main.ts`

--- a/docs/10-19_product/10-v0-requirements.md
+++ b/docs/10-19_product/10-v0-requirements.md
@@ -66,6 +66,9 @@ This document defines what the system must do, not how it is implemented.
 - The assistant has its own email address and mailbox.
 - The assistant reads only its own mailbox by default.
 - Emails forwarded to the assistant are treated as delegated work items.
+- Delivery is phased:
+  - phase 1: delegated email interpretation and draft generation
+  - phase 2: approval-gated outbound email sending
 - The assistant may:
   - classify emails
   - draft replies
@@ -144,6 +147,7 @@ This document defines what the system must do, not how it is implemented.
 ### 9.1 Must Have
 - Telegram interaction
 - Assistant identity (email + GitHub accounts exist)
+- Forwarded-email delegation with summary and draft-reply support
 - Delegation + safety model
 - Audit logging
 - Support for self-building workflows
@@ -155,6 +159,9 @@ This document defines what the system must do, not how it is implemented.
 - Multi-user collaboration
 - Full project management system
 - Fully predefined reminder/scheduling UX (should emerge through iterative collaboration)
+
+Note:
+- "Assistant email identity exists" means credentials and account can be provisioned for delegated use; it does not imply autonomous inbox operations in v0.
 
 ## 10. Open Decisions (Deferred)
 - Assistant name / handle

--- a/docs/20-29_architecture/20-v0-architecture-effectts.md
+++ b/docs/20-29_architecture/20-v0-architecture-effectts.md
@@ -21,21 +21,30 @@ The assistant runtime is intentionally thin:
 
 1. Telegram message arrives.
 2. Runtime computes `sessionKey = chatId + ":" + (threadId || "root")`.
-3. Runtime loads persisted `opencodeSessionId` for session key (if any).
-4. Runtime relays message to OpenCode using:
+3. Runtime resolves active workspace for topic (default `assistantRepoPath`).
+4. Runtime loads persisted `opencodeSessionId` for `(topicKey, workspacePath)`.
+5. Runtime relays message to OpenCode using:
    - `opencode run --attach <url> --format json`
    - plus `--session <id>` when a prior session exists.
-5. Runtime parses OpenCode JSON events, captures returned `sessionID`, persists mapping.
-6. Runtime sends response back to the same chat/topic.
+   - process `cwd` set to active workspace path.
+6. Runtime parses OpenCode JSON events, captures returned `sessionID`, persists mapping.
+7. Runtime sends response back to the same chat/topic.
 
 ## 4. Session Continuity
 
 Persistence contract:
-- `sessionKey`
+- `topicKey` (`chatId:threadId`)
+- `workspacePath`
+- `sessionKey` (`[topicKey, workspacePath]`)
 - `opencodeSessionId`
 - `lastUsedAt`
 - `status` (`active|stale`)
 - Telegram polling cursor
+
+Workspace contract:
+- topic-to-active-workspace binding is persisted
+- per-topic workspace history is persisted
+- switching workspaces does not destroy prior workspace session continuity
 
 Runtime behavior:
 - In-memory session hints with LRU/idle eviction.
@@ -43,10 +52,15 @@ Runtime behavior:
   - idle timeout: 45 minutes
   - max in-memory sessions: 5
   - retry attempts on stale session: 1
-- If resumed session fails:
+  - relay timeout: 5 minutes
+  - progress updates: first at 10 seconds, then every 30 seconds (max 3)
+- If resumed session fails with `session_invalid`:
   - mark mapping stale
   - retry once with no session id
   - persist new returned session id if retry succeeds
+- If resumed session fails with timeout/transport errors:
+  - keep existing mapping
+  - return a user-visible failure response
 
 ## 5. OpenCode Lifecycle
 
@@ -63,6 +77,13 @@ This keeps local ops lightweight and self-healing.
 - Later `/start` messages are ignored.
 - All other messages are relayed as plain conversation text.
 - Topics are first-class via `message_thread_id` routing.
+
+Deterministic wrapper intents (control plane):
+- `use repo <path>`: switch active workspace for this topic
+- `where am i` / `pwd`: report active workspace path
+- `list repos` / `repos`: list known workspaces for this topic
+
+All other messages remain normal relay turns to OpenCode.
 
 ## 7. Safety Ownership
 
@@ -103,3 +124,4 @@ Key settings:
 - Telegram: token, poll interval
 - OpenCode: binary, model, attach URL, auto-start host/port
 - Sessions: idle timeout, max concurrent, retry attempts
+- Relay behavior: timeout, progress first interval, progress repeat interval, progress max count

--- a/docs/30-39_execution/30-v0-working-plan.md
+++ b/docs/30-39_execution/30-v0-working-plan.md
@@ -36,6 +36,10 @@ Track execution for the thin Telegram-to-OpenCode relay runtime and keep roadmap
 
 ## Next Milestones
 
+Feature planning note:
+- Reliability/ops milestones (R3+) remain active for runtime hardening.
+- Email capability milestones (R5/R6) are the next product-facing feature track and should proceed as thin wrapper slices.
+
 ### R1 - Docs and Scope Convergence
 Scope:
 - Remove stale workflow-era milestones from active plan
@@ -76,10 +80,33 @@ Exit criteria:
 - Active repository surface matches documented runtime surface
 - No ambiguous ownership of legacy workflow modules remains
 
+### R5 - Email Delegation (Read + Draft, No Send)
+Scope:
+- Accept delegated email content (forwarded by user) as conversational work input
+- Produce concise email summaries, draft reply options, and proposed action items in Telegram
+- Keep wrapper responsibilities transport-level and avoid mailbox automation in hot path
+
+Exit criteria:
+- Delegated email content can be processed end-to-end through Telegram relay turns
+- Assistant returns useful summary + draft replies without sending external messages
+- No outbound email side effects are introduced
+
+### R6 - Email Send (Approval-Gated)
+Scope:
+- Add send preview contract for outbound email drafts
+- Require explicit `Approve` decision before any send action
+- Keep approval and safety ownership primarily in OpenCode; wrapper only handles transport/state handoff
+
+Exit criteria:
+- Outbound email send requires explicit approval and is rejected otherwise
+- Deny/revise flows keep conversation continuity and do not send
+- Operator-visible logs clearly show preview, decision, and final send outcome
+
 ## Risks
 - API drift in Telegram/OpenCode transport behavior can cause relay instability
 - Legacy modules drifting unnoticed can confuse roadmap and quality signals
 - Over-expanding wrapper responsibilities can duplicate OpenCode safety ownership
+- Email provider integration and identity setup can create operational complexity if introduced too early
 
 ## Definition of Done (Per Milestone)
 - Changes keep wrapper responsibilities transport-level and minimal
@@ -103,10 +130,22 @@ Template:
 - Blockers/notes:
 
 2026-02-08
+- Completed: Added per-topic workspace switching with deterministic workspace intents and per-workspace session continuity.
+- Decisions: Kept wrapper intent handling deterministic for control-plane actions (`use repo`, `where am i`, `list repos`) and delegated all non-control conversation to OpenCode.
+- Files changed: `apps/assistant-core/src/worker.ts`, `apps/assistant-core/src/worker.test.ts`, `apps/assistant-core/src/session-store.ts`, `apps/assistant-core/src/main.ts`, `packages/ports/src/index.ts`, `packages/adapters-model-opencode-cli/src/index.ts`, `docs/20-29_architecture/20-v0-architecture-effectts.md`, `docs/30-39_execution/31-v0-implementation-blueprint.md`, `docs/30-39_execution/30-v0-working-plan.md`.
+- Blockers/notes: None.
+
+2026-02-08
 - Completed: Executed R4 boundary cleanup by removing legacy workflow-era packages that were out of the active relay runtime path.
 - Decisions: Archived-by-removal for unused modules to keep active repository surface aligned with documented runtime scope and CI/lint signals.
 - Files changed: `packages/adapters-github/package.json`, `packages/adapters-github/src/index.ts`, `packages/adapters-sqlite/package.json`, `packages/adapters-sqlite/src/index.ts`, `packages/adapters-sqlite/src/index.test.ts`, `packages/policy/package.json`, `packages/policy/src/index.ts`, `packages/audit/package.json`, `packages/audit/src/index.ts`, `docs/30-39_execution/30-v0-working-plan.md`.
 - Blockers/notes: None.
+
+2026-02-08
+- Completed: Added the next feature track for email delegation and approval-gated sending as R5/R6.
+- Decisions: Sequence email delivery in two slices (`read+draft` first, `send` second) to preserve thin runtime scope and explicit approval guarantees.
+- Files changed: `docs/30-39_execution/30-v0-working-plan.md`, `docs/10-19_product/10-v0-requirements.md`, `docs/20-29_architecture/20-v0-architecture-effectts.md`, `docs/00-09_meta/00-index.md`.
+- Blockers/notes: Provider choice and assistant mailbox identity setup remain deferred prerequisites for implementation.
 
 2026-02-08
 - Completed: Aligned active working plan to the thin relay runtime and replaced stale workflow-era milestones with relay-native milestones (R1-R4).

--- a/packages/adapters-model-opencode-cli/src/index.ts
+++ b/packages/adapters-model-opencode-cli/src/index.ts
@@ -35,6 +35,7 @@ export class OpencodeCliModelAdapter implements ModelPort {
     const result = await this.runOpencodeSession(
       input.text,
       input.sessionId ?? null,
+      input.workspacePath,
     );
     if (result.exitCode !== 0) {
       const details = result.stderr.trim() || result.textOutput || "no output";
@@ -84,6 +85,7 @@ export class OpencodeCliModelAdapter implements ModelPort {
   private async runOpencodeSession(
     message: string,
     sessionId: string | null,
+    workspacePath?: string,
   ): Promise<SessionCommandResult> {
     const cmd = [
       this.binaryPath,
@@ -103,7 +105,7 @@ export class OpencodeCliModelAdapter implements ModelPort {
 
     const proc = Bun.spawn({
       cmd,
-      cwd: this.repoPath,
+      cwd: workspacePath ?? this.repoPath,
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/packages/ports/src/index.ts
+++ b/packages/ports/src/index.ts
@@ -21,6 +21,7 @@ export type RespondInput = {
   context: string[];
   pendingProposalWorkItemId: string | null;
   sessionId?: string | null;
+  workspacePath?: string;
 };
 
 export interface ModelPort {


### PR DESCRIPTION
## Summary
- add deterministic workspace control intents (`use repo`, `where am i`, `list repos`) so one Telegram topic can switch directories safely without relying on model interpretation
- scope OpenCode session continuity by `(topic, workspace)` and run relay turns with `cwd` bound to the active workspace path
- persist topic workspace bindings/history in SQLite and align architecture/execution docs with workspace-aware routing behavior

## Validation
- bun run verify