### PR TITLE
add supervisor-managed graceful restart flow

### DIFF
--- a/apps/assistant-core/src/http.ts
+++ b/apps/assistant-core/src/http.ts
@@ -15,8 +15,8 @@ export const startHttpServer = ({
   config,
   sessionStore,
   modelPort,
-}: Deps): void => {
-  Bun.serve({
+}: Deps): Bun.Server<unknown> => {
+  return Bun.serve({
     port: config.port,
     fetch: async (request: Request) => {
       const url = new URL(request.url);

--- a/docs/00-09_meta/00-index.md
+++ b/docs/00-09_meta/00-index.md
@@ -7,6 +7,7 @@ Knowledge Index (Johnny Decimal)
 - Topic-aware session continuity (`chatId:threadId`): active
 - Persistent session/cursor store: active
 - Topic workspace switching with per-workspace session continuity: active
+- Supervisor-managed graceful worker restart: active
 - OpenCode auto-start (`opencode serve`) + attach flow: active
 - Minimal ops surface (`/health`, `/ready`): active
 - CI quality gate is active: `bun run verify`

--- a/docs/20-29_architecture/20-v0-architecture-effectts.md
+++ b/docs/20-29_architecture/20-v0-architecture-effectts.md
@@ -11,8 +11,8 @@ The assistant runtime is intentionally thin:
 
 ## 2. Runtime Topology
 
-- Single Bun process (`apps/assistant-core`)
-- In-process Telegram long poll worker
+- Supervisor Bun process (`apps/assistant-core`) with one managed worker child
+- In-worker Telegram long poll loop
 - Local SQLite for session mapping and Telegram cursor persistence
 - Local OpenCode server (`opencode serve`) attached via HTTP
 - Minimal HTTP endpoints for ops (`/health`, `/ready`)
@@ -82,8 +82,15 @@ Deterministic wrapper intents (control plane):
 - `use repo <path>`: switch active workspace for this topic
 - `where am i` / `pwd`: report active workspace path
 - `list repos` / `repos`: list known workspaces for this topic
+- `restart assistant` / `restart`: request graceful worker restart
 
 All other messages remain normal relay turns to OpenCode.
+
+Restart behavior:
+- worker acknowledges restart intent to chat
+- worker enters drain mode (stop polling new updates, finish in-flight turn)
+- worker exits with restart code
+- supervisor starts fresh worker process automatically
 
 ## 7. Safety Ownership
 

--- a/docs/30-39_execution/30-v0-working-plan.md
+++ b/docs/30-39_execution/30-v0-working-plan.md
@@ -130,6 +130,12 @@ Template:
 - Blockers/notes:
 
 2026-02-08
+- Completed: Added supervisor-managed rolling restart flow so chat-triggered restarts drain gracefully and auto-recover.
+- Decisions: Introduced deterministic runtime restart intent (`restart assistant`/`restart`) in wrapper control plane and delegated process relaunch to supervisor to avoid manual restart loops.
+- Files changed: `apps/assistant-core/src/main.ts`, `apps/assistant-core/src/worker.ts`, `apps/assistant-core/src/worker.test.ts`, `apps/assistant-core/src/http.ts`, `docs/20-29_architecture/20-v0-architecture-effectts.md`, `docs/30-39_execution/31-v0-implementation-blueprint.md`, `docs/30-39_execution/30-v0-working-plan.md`.
+- Blockers/notes: Overlapping zero-downtime handoff is not implemented because worker and replacement bind the same ops port; current flow is graceful stop/start with fast restart.
+
+2026-02-08
 - Completed: Added per-topic workspace switching with deterministic workspace intents and per-workspace session continuity.
 - Decisions: Kept wrapper intent handling deterministic for control-plane actions (`use repo`, `where am i`, `list repos`) and delegated all non-control conversation to OpenCode.
 - Files changed: `apps/assistant-core/src/worker.ts`, `apps/assistant-core/src/worker.test.ts`, `apps/assistant-core/src/session-store.ts`, `apps/assistant-core/src/main.ts`, `packages/ports/src/index.ts`, `packages/adapters-model-opencode-cli/src/index.ts`, `docs/20-29_architecture/20-v0-architecture-effectts.md`, `docs/30-39_execution/31-v0-implementation-blueprint.md`, `docs/30-39_execution/30-v0-working-plan.md`.


### PR DESCRIPTION
## Summary
- introduce a lightweight supervisor process that manages a worker child and automatically restarts it on planned restart exits or unexpected crashes
- add deterministic runtime restart intent (`restart assistant` / `restart`) that acknowledges in chat, drains polling, and triggers a supervised worker restart
- keep restart behavior documented and add tests proving restart intent is handled wrapper-side without model delegation

## Validation
- bun run verify