### PR TITLE
add runtime version fingerprinting and startup restart acknowledgements

### DIFF
--- a/apps/assistant-core/src/version.test.ts
+++ b/apps/assistant-core/src/version.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { loadBuildInfo } from "./version";
+
+describe("loadBuildInfo", () => {
+  test("uses package version and falls back when git is unavailable", async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "delegate-version-"));
+    await writeFile(
+      join(repoRoot, "package.json"),
+      JSON.stringify({ name: "delegate-assistant", version: "0.2.0" }),
+      "utf8",
+    );
+
+    try {
+      const buildInfo = loadBuildInfo({
+        repoRoot,
+        env: { BUILD_TIME_UTC: "2026-02-08T12:00:00.000Z" },
+      });
+      expect(buildInfo.service).toBe("delegate-assistant");
+      expect(buildInfo.releaseVersion).toBe("0.2.0");
+      expect(buildInfo.displayVersion).toBe("0.2.0");
+      expect(buildInfo.gitSha).toBe("unknown");
+      expect(buildInfo.gitBranch).toBe("unknown");
+      expect(buildInfo.commitTitle).toBe("unknown");
+      expect(buildInfo.buildTimeUtc).toBe("2026-02-08T12:00:00.000Z");
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("uses env-provided git metadata when present", () => {
+    const buildInfo = loadBuildInfo({
+      repoRoot: process.cwd(),
+      now: () => new Date("2026-02-08T01:02:03.000Z"),
+      env: {
+        GIT_SHA: "68ca6cd437276a993500787a2e809e38ad3ae598",
+        GIT_BRANCH: "main",
+        GIT_COMMIT_TITLE: "add supervisor-managed graceful restart flow",
+      },
+    });
+
+    expect(buildInfo.gitSha).toBe("68ca6cd437276a993500787a2e809e38ad3ae598");
+    expect(buildInfo.gitShortSha).toBe("68ca6cd");
+    expect(buildInfo.gitBranch).toBe("main");
+    expect(buildInfo.commitTitle).toBe(
+      "add supervisor-managed graceful restart flow",
+    );
+    expect(buildInfo.displayVersion.endsWith("+68ca6cd")).toBeTrue();
+  });
+});

--- a/apps/assistant-core/src/version.ts
+++ b/apps/assistant-core/src/version.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+type RuntimeInfo = {
+  bunVersion: string;
+  nodeCompat: string;
+};
+
+export type BuildInfo = {
+  service: string;
+  releaseVersion: string;
+  displayVersion: string;
+  gitSha: string;
+  gitShortSha: string;
+  gitBranch: string;
+  commitTitle: string;
+  buildTimeUtc: string;
+  runtime: RuntimeInfo;
+};
+
+type BuildInfoInput = {
+  repoRoot?: string;
+  now?: () => Date;
+  env?: Record<string, string | undefined>;
+};
+
+const UNKNOWN = "unknown";
+
+const readText = (value: Uint8Array<ArrayBufferLike>): string =>
+  new TextDecoder().decode(value).trim();
+
+const readGitValue = (repoRoot: string, args: string[]): string | null => {
+  const command = Bun.spawnSync({
+    cmd: ["git", ...args],
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  if (command.exitCode !== 0) {
+    return null;
+  }
+
+  const output = readText(command.stdout);
+  return output.length > 0 ? output : null;
+};
+
+const resolveRepoRoot = (): string => resolve(import.meta.dir, "../../..");
+
+const readRootPackage = (
+  repoRoot: string,
+): { name?: string; version?: string } => {
+  try {
+    const packageJsonPath = join(repoRoot, "package.json");
+    const raw = readFileSync(packageJsonPath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as { name?: string; version?: string };
+  } catch {
+    return {};
+  }
+};
+
+const asNonEmpty = (value: string | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const shortSha = (sha: string): string => {
+  if (sha === UNKNOWN) {
+    return UNKNOWN;
+  }
+  return sha.slice(0, 7);
+};
+
+export const formatVersionFingerprint = (buildInfo: BuildInfo): string =>
+  `${buildInfo.service} ${buildInfo.displayVersion} (branch ${buildInfo.gitBranch}, built ${buildInfo.buildTimeUtc}) - ${buildInfo.commitTitle}`;
+
+export const loadBuildInfo = (input: BuildInfoInput = {}): BuildInfo => {
+  const repoRoot = input.repoRoot ?? resolveRepoRoot();
+  const env = input.env ?? process.env;
+  const now = input.now ?? (() => new Date());
+  const packageJson = readRootPackage(repoRoot);
+
+  const service = asNonEmpty(packageJson.name) ?? "delegate-assistant";
+  const releaseVersion = asNonEmpty(packageJson.version) ?? "0.0.0";
+  const gitSha =
+    asNonEmpty(env.GIT_SHA) ??
+    readGitValue(repoRoot, ["rev-parse", "HEAD"]) ??
+    UNKNOWN;
+  const gitBranch =
+    asNonEmpty(env.GIT_BRANCH) ??
+    readGitValue(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]) ??
+    UNKNOWN;
+  const commitTitle =
+    asNonEmpty(env.GIT_COMMIT_TITLE) ??
+    readGitValue(repoRoot, ["log", "-1", "--pretty=%s"]) ??
+    UNKNOWN;
+  const buildTimeUtc = asNonEmpty(env.BUILD_TIME_UTC) ?? now().toISOString();
+  const gitShortSha = shortSha(gitSha);
+  const displayVersion =
+    gitShortSha === UNKNOWN
+      ? releaseVersion
+      : `${releaseVersion}+${gitShortSha}`;
+
+  return {
+    service,
+    releaseVersion,
+    displayVersion,
+    gitSha,
+    gitShortSha,
+    gitBranch,
+    commitTitle,
+    buildTimeUtc,
+    runtime: {
+      bunVersion: Bun.version,
+      nodeCompat: process.versions.node,
+    },
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "delegate-assistant",
   "private": true,
+  "version": "0.1.0",
   "type": "module",
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## Summary
- add runtime build metadata loading and expose it consistently in startup logs, `GET /version`, and deterministic chat `version` replies
- include commit title in the version fingerprint so operators can identify the running change immediately from chat or HTTP
- persist chat-triggered restart acknowledgements in sqlite and flush them on startup so restarts proactively confirm recovery without waiting for another prompt

## Verification
- bun run verify