### PR TITLE
enforce strict version policy checks in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Enforce version policy
+        run: |
+          export GIT_SHA="$(git rev-parse HEAD)"
+          export GIT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          export GIT_COMMIT_TITLE="$(git log -1 --pretty=%s)"
+          bun run policy:version
+
       - name: Verify
         run: bun run verify

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ Current runtime entrypoints:
 - `packages/adapters-telegram/src/index.ts`
 - `packages/adapters-model-opencode-cli/src/index.ts`
 
+## Version Policy
+
+CI enforces strict version metadata before running the full verify pipeline.
+
+- Root `package.json` must contain a valid SemVer `version`.
+- On tag builds (`refs/tags/vX.Y.Z`), the tag version must exactly match `package.json`.
+- In CI, runtime metadata must be present and non-ambiguous:
+  - `GIT_SHA` (40-char lowercase sha)
+  - `GIT_BRANCH` (not `unknown`)
+  - `GIT_COMMIT_TITLE` (not `unknown`)
+
+Run locally:
+- `bun run policy:version`
+
 ## Manage macOS user service (launchd)
 
 Use these commands to manage the local `bun run dev` LaunchAgent on macOS.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "bun run --cwd apps/assistant-core typecheck",
     "build": "bun run --cwd apps/assistant-core build",
     "test": "bun test",
+    "policy:version": "bun run scripts/check-version-policy.ts",
     "lint": "oxlint apps/**/src packages/**/src --deny-warnings",
     "format": "biome check --write apps/**/src packages/**/src docs README.md .github",
     "format:check": "biome check apps/**/src packages/**/src docs README.md .github",

--- a/scripts/check-version-policy.test.ts
+++ b/scripts/check-version-policy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import { validateVersionPolicy } from "./check-version-policy";
+
+describe("validateVersionPolicy", () => {
+  test("passes for valid non-CI local checks", () => {
+    const errors = validateVersionPolicy({
+      packageVersion: "1.2.3",
+      env: {
+        CI: "false",
+      },
+    });
+
+    expect(errors).toHaveLength(0);
+  });
+
+  test("fails when package version is not semver", () => {
+    const errors = validateVersionPolicy({
+      packageVersion: "1.2",
+      env: {
+        CI: "false",
+      },
+    });
+
+    expect(errors[0]).toContain("valid SemVer");
+  });
+
+  test("fails when release tag version mismatches package version", () => {
+    const errors = validateVersionPolicy({
+      packageVersion: "1.2.3",
+      env: {
+        CI: "false",
+        GITHUB_REF: "refs/tags/v1.2.4",
+      },
+    });
+
+    expect(errors).toContain(
+      "release tag version (1.2.4) must match package.json version (1.2.3)",
+    );
+  });
+
+  test("fails in CI when build metadata is missing", () => {
+    const errors = validateVersionPolicy({
+      packageVersion: "1.2.3",
+      env: {
+        CI: "true",
+        GIT_SHA: "",
+        GIT_BRANCH: "unknown",
+        GIT_COMMIT_TITLE: "",
+      },
+    });
+
+    expect(errors).toContain(
+      "GIT_SHA must be set to a full 40-char lowercase git commit sha",
+    );
+    expect(errors).toContain("GIT_BRANCH must be set and not 'unknown'");
+    expect(errors).toContain("GIT_COMMIT_TITLE must be set and not 'unknown'");
+  });
+
+  test("passes in CI with complete metadata", () => {
+    const errors = validateVersionPolicy({
+      packageVersion: "1.2.3",
+      env: {
+        CI: "true",
+        GIT_SHA: "68ca6cd437276a993500787a2e809e38ad3ae598",
+        GIT_BRANCH: "main",
+        GIT_COMMIT_TITLE: "add strict version policy checks",
+      },
+    });
+
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/scripts/check-version-policy.ts
+++ b/scripts/check-version-policy.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type VersionPolicyInput = {
+  env?: Record<string, string | undefined>;
+  packageVersion: string;
+};
+
+const semverPattern =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+const shaPattern = /^[a-f0-9]{40}$/;
+
+const asNonEmpty = (value: string | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const getTagVersion = (ref: string | undefined): string | null => {
+  if (!ref?.startsWith("refs/tags/v")) {
+    return null;
+  }
+  return ref.slice("refs/tags/v".length);
+};
+
+const requiresCiMetadata = (env: Record<string, string | undefined>): boolean =>
+  env.CI === "true";
+
+export const validateVersionPolicy = (
+  input: VersionPolicyInput,
+): string[] => {
+  const env = input.env ?? process.env;
+  const errors: string[] = [];
+  const packageVersion = input.packageVersion;
+
+  if (!semverPattern.test(packageVersion)) {
+    errors.push(
+      `package.json version must be valid SemVer (received ${packageVersion})`,
+    );
+  }
+
+  const tagVersion = getTagVersion(env.GITHUB_REF);
+  if (tagVersion !== null) {
+    if (!semverPattern.test(tagVersion)) {
+      errors.push(`release tag must match vX.Y.Z SemVer (received ${tagVersion})`);
+    }
+
+    if (tagVersion !== packageVersion) {
+      errors.push(
+        `release tag version (${tagVersion}) must match package.json version (${packageVersion})`,
+      );
+    }
+  }
+
+  if (!requiresCiMetadata(env)) {
+    return errors;
+  }
+
+  const gitSha = asNonEmpty(env.GIT_SHA);
+  if (!gitSha || !shaPattern.test(gitSha)) {
+    errors.push("GIT_SHA must be set to a full 40-char lowercase git commit sha");
+  }
+
+  const gitBranch = asNonEmpty(env.GIT_BRANCH);
+  if (!gitBranch || gitBranch === "unknown") {
+    errors.push("GIT_BRANCH must be set and not 'unknown'");
+  }
+
+  const commitTitle = asNonEmpty(env.GIT_COMMIT_TITLE);
+  if (!commitTitle || commitTitle === "unknown") {
+    errors.push("GIT_COMMIT_TITLE must be set and not 'unknown'");
+  }
+
+  return errors;
+};
+
+const loadRootPackageVersion = (): string => {
+  const rootPackagePath = join(import.meta.dir, "..", "package.json");
+  const raw = readFileSync(rootPackagePath, "utf8");
+  const parsed = JSON.parse(raw) as { version?: unknown };
+  if (typeof parsed.version !== "string") {
+    throw new Error("package.json version field must be a string");
+  }
+  return parsed.version;
+};
+
+const run = (): void => {
+  const packageVersion = loadRootPackageVersion();
+  const errors = validateVersionPolicy({ packageVersion });
+
+  if (errors.length > 0) {
+    for (const error of errors) {
+      console.error(`version-policy: ${error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("version-policy: ok");
+};
+
+if (import.meta.main) {
+  run();
+}


### PR DESCRIPTION
## Summary
- add a strict version policy checker that validates SemVer, tag-to-package version alignment, and required CI runtime metadata (`GIT_SHA`, `GIT_BRANCH`, `GIT_COMMIT_TITLE`)
- add policy coverage tests for invalid versions, mismatched tag refs, missing CI metadata, and happy-path CI validation
- run the policy check in CI before `bun run verify`, and document the rules + local command in `README.md`

## Verification
- bun run policy:version
- bun run verify