### PR TITLE
Add Telegram scheduled reminder delivery in worker

### DIFF
--- a/apps/assistant-core/src/session-store.ts
+++ b/apps/assistant-core/src/session-store.ts
@@ -1,6 +1,7 @@
 export {
   decodeSessionKeyId,
   encodeSessionKeyId,
+  type PendingScheduledDeliveryAck,
   type PendingStartupAck,
   parseSessionKey,
   type SessionListFilters,

--- a/packages/adapters-session-store-sqlite/src/index.test.ts
+++ b/packages/adapters-session-store-sqlite/src/index.test.ts
@@ -80,4 +80,38 @@ describe("SqliteSessionStore admin queries", () => {
       await cleanup();
     }
   });
+
+  test("excludes schedules with pending delivery ack from due query", async () => {
+    const { store, cleanup } = await buildStore();
+
+    try {
+      const createdAt = "2026-02-08T00:00:00.000Z";
+      const nowIso = "2026-02-13T19:01:00.000Z";
+
+      for (let i = 0; i < 205; i += 1) {
+        const id = await store.enqueueScheduledMessage({
+          chatId: "chat-overflow",
+          threadId: null,
+          text: `Reminder ${i}`,
+          sendAt: "2000-01-01T00:00:00.000Z",
+          createdAt,
+        });
+        await store.upsertPendingScheduledDeliveryAck({
+          id,
+          chatId: "chat-overflow",
+          deliveredAt: nowIso,
+          nextAttemptAt: nowIso,
+        });
+      }
+
+      const due = await store.listDueScheduledMessages({
+        nowIso,
+        limit: 500,
+      });
+
+      expect(due).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add deterministic `remind me on/at <time> to <message>` handling in the Telegram worker so reminders can be queued without going through OpenCode
- add scheduled-message flushing each worker cycle to deliver due reminders and retry on send failures
- add worker tests covering reminder queuing and due reminder delivery

## Notes
- when persistent scheduling methods are unavailable in the session store, reminders are queued in-memory with an explicit caveat that they are lost on restart
- this PR intentionally commits only worker scheduling changes; unrelated local workspace changes are excluded