### PR TITLE
refactor: separate src from tests and add workspace aliases

### DIFF
--- a/apps/assistant-core/package.json
+++ b/apps/assistant-core/package.json
@@ -6,7 +6,7 @@
     "dev": "bun run src/main.ts",
     "typecheck": "bunx tsc --project tsconfig.json --noEmit",
     "build": "bun build src/main.ts --target bun --outdir dist",
-    "test": "bun test"
+    "test": "bun test tests/"
   },
   "dependencies": {
     "@delegate/adapters-session-store-sqlite": "workspace:*",

--- a/apps/assistant-core/src/http.ts
+++ b/apps/assistant-core/src/http.ts
@@ -1,7 +1,7 @@
+import type { AppConfig } from "@assistant-core/src/config";
+import { probeOpencodeReachability } from "@assistant-core/src/opencode-server";
+import type { BuildInfo } from "@assistant-core/src/version";
 import type { ModelPort } from "@delegate/ports";
-import type { AppConfig } from "./config";
-import { probeOpencodeReachability } from "./opencode-server";
-import type { BuildInfo } from "./version";
 
 type Deps = {
   config: AppConfig;

--- a/apps/assistant-core/src/main.ts
+++ b/apps/assistant-core/src/main.ts
@@ -1,16 +1,18 @@
-import { OpencodeCliModelAdapter } from "@delegate/adapters-model-opencode-cli";
-import { DeterministicModelStub } from "@delegate/adapters-model-stub";
-import { TelegramLongPollingAdapter } from "@delegate/adapters-telegram";
-
-import { loadConfig } from "./config";
-import { startHttpServer } from "./http";
+import { loadConfig } from "@assistant-core/src/config";
+import { startHttpServer } from "@assistant-core/src/http";
 import {
   ensureOpencodeServer,
   probeOpencodeReachability,
-} from "./opencode-server";
-import { SqliteSessionStore } from "./session-store";
-import { formatVersionFingerprint, loadBuildInfo } from "./version";
-import { startTelegramWorker } from "./worker";
+} from "@assistant-core/src/opencode-server";
+import { SqliteSessionStore } from "@assistant-core/src/session-store";
+import {
+  formatVersionFingerprint,
+  loadBuildInfo,
+} from "@assistant-core/src/version";
+import { startTelegramWorker } from "@assistant-core/src/worker";
+import { OpencodeCliModelAdapter } from "@delegate/adapters-model-opencode-cli";
+import { DeterministicModelStub } from "@delegate/adapters-model-stub";
+import { TelegramLongPollingAdapter } from "@delegate/adapters-telegram";
 
 const RESTART_EXIT_CODE = 75;
 const WORKER_ROLE = "worker";

--- a/apps/assistant-core/src/worker.ts
+++ b/apps/assistant-core/src/worker.ts
@@ -1,9 +1,12 @@
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  type BuildInfo,
+  formatVersionFingerprint,
+} from "@assistant-core/src/version";
 import type { InboundMessage } from "@delegate/domain";
 import type { ChatPort, ModelPort } from "@delegate/ports";
-import { type BuildInfo, formatVersionFingerprint } from "./version";
 
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => {

--- a/apps/assistant-core/tests/http.test.ts
+++ b/apps/assistant-core/tests/http.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
-import type { AppConfig } from "./config";
-import { runReadinessChecks, startHttpServer } from "./http";
-import type { BuildInfo } from "./version";
+import type { AppConfig } from "@assistant-core/src/config";
+import { runReadinessChecks, startHttpServer } from "@assistant-core/src/http";
+import type { BuildInfo } from "@assistant-core/src/version";
 
 const baseConfig = (): AppConfig => ({
   configSourcePath: "/tmp/config.json",

--- a/apps/assistant-core/tests/main.test.ts
+++ b/apps/assistant-core/tests/main.test.ts
@@ -4,7 +4,7 @@ import {
   classifyWorkerExit,
   reclaimPortFromPriorAssistant,
   startWithPortTakeover,
-} from "./main";
+} from "@assistant-core/src/main";
 
 describe("startWithPortTakeover", () => {
   test("returns immediately when first bind succeeds", async () => {

--- a/apps/assistant-core/tests/opencode-server.test.ts
+++ b/apps/assistant-core/tests/opencode-server.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { ensureOpencodeServer } from "./opencode-server";
+import { ensureOpencodeServer } from "@assistant-core/src/opencode-server";
 
 describe("ensureOpencodeServer", () => {
   test("does not spawn when transport is already reachable", async () => {

--- a/apps/assistant-core/tests/version.test.ts
+++ b/apps/assistant-core/tests/version.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { loadBuildInfo } from "./version";
+import { loadBuildInfo } from "@assistant-core/src/version";
 
 describe("loadBuildInfo", () => {
   test("uses package version and falls back when git is unavailable", async () => {

--- a/apps/assistant-core/tests/worker.test.ts
+++ b/apps/assistant-core/tests/worker.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
+import type { BuildInfo } from "@assistant-core/src/version";
+import {
+  flushPendingStartupAck,
+  handleChatMessage,
+} from "@assistant-core/src/worker";
 import type {
   InboundMessage,
   ModelTurnResponse,
@@ -14,8 +18,6 @@ import type {
   ModelPort,
   RespondInput,
 } from "@delegate/ports";
-import type { BuildInfo } from "./version";
-import { flushPendingStartupAck, handleChatMessage } from "./worker";
 
 class CapturingChatPort implements ChatPort {
   readonly sent: OutboundMessage[] = [];

--- a/packages/adapters-session-store-sqlite/package.json
+++ b/packages/adapters-session-store-sqlite/package.json
@@ -2,6 +2,9 @@
   "name": "@delegate/adapters-session-store-sqlite",
   "private": true,
   "type": "module",
+  "scripts": {
+    "test": "bun test tests/"
+  },
   "exports": {
     ".": "./src/index.ts"
   }

--- a/packages/adapters-session-store-sqlite/tests/index.test.ts
+++ b/packages/adapters-session-store-sqlite/tests/index.test.ts
@@ -6,7 +6,7 @@ import {
   decodeSessionKeyId,
   encodeSessionKeyId,
   SqliteSessionStore,
-} from "./index";
+} from "@delegate/adapters-session-store-sqlite";
 
 const buildStore = async (): Promise<{
   store: SqliteSessionStore;

--- a/scripts/tests/check-version-policy.test.ts
+++ b/scripts/tests/check-version-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { validateVersionPolicy } from "./check-version-policy";
+import { validateVersionPolicy } from "../check-version-policy";
 
 describe("validateVersionPolicy", () => {
   test("passes for valid non-CI local checks", () => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,8 +8,20 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
-    "types": [
-      "bun-types"
-    ]
+    "types": ["bun-types"],
+    "baseUrl": ".",
+    "paths": {
+      "@assistant-core/src/*": ["apps/assistant-core/src/*"],
+      "@delegate/domain/*": ["packages/domain/src/*"],
+      "@delegate/ports/*": ["packages/ports/src/*"],
+      "@delegate/adapters-telegram/*": ["packages/adapters-telegram/src/*"],
+      "@delegate/adapters-model-opencode-cli/*": [
+        "packages/adapters-model-opencode-cli/src/*"
+      ],
+      "@delegate/adapters-model-stub/*": ["packages/adapters-model-stub/src/*"],
+      "@delegate/adapters-session-store-sqlite/*": [
+        "packages/adapters-session-store-sqlite/src/*"
+      ]
+    }
   }
 }


### PR DESCRIPTION
- Remove 4 empty packages (adapters-github, adapters-sqlite, audit, policy)
- Add workspace aliases to tsconfig.base.json for cleaner imports
- Move test files from src/ to tests/ directories
- Update all relative imports to use workspace aliases
- Fix package exports for proper alias resolution
- Update package.json test scripts to point to tests/ directories

This achieves clean separation of production and test code while making imports resilient to file moves and directory restructuring.

## Summary
- Describe what changed and why.

## Validation
- [ ] `bun run verify`
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run format:check`
- [ ] `bun run build`
- [ ] `bun run test`
- [ ] `bun run docs:check`

## Safety
- [ ] No secrets or credentials added
- [ ] Scope is focused and reviewable
