### PR TITLE
fix: installer stdin for curl|bash

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,7 +41,7 @@ prompt_value() {
   else
     printf '%s: ' "$prompt" >&2
   fi
-  read -r value
+  read -r value < /dev/tty
   value="${value:-$default}"
   if [ -z "$value" ]; then
     die "${var_name} is required"
@@ -145,9 +145,13 @@ setup_config() {
   info "Configuring delegate-assistant..."
   echo ""
 
-  # prompt for required values
-  local bot_token
-  bot_token=$(prompt_value "TELEGRAM_BOT_TOKEN" "Telegram bot token (required)")
+  # use env var if set, otherwise prompt interactively
+  local bot_token="${TELEGRAM_BOT_TOKEN:-}"
+  if [ -z "$bot_token" ]; then
+    bot_token=$(prompt_value "TELEGRAM_BOT_TOKEN" "Telegram bot token (required)")
+  else
+    info "Using TELEGRAM_BOT_TOKEN from environment"
+  fi
 
   # write secrets
   cat > "$SECRETS_FILE" << EOF


### PR DESCRIPTION
## Summary

- Fix `read` in install.sh to read from `/dev/tty` instead of stdin, so `curl | bash` works correctly
- Support `TELEGRAM_BOT_TOKEN` env var to skip interactive prompt (useful for automation)

## Problem

When running `curl -fsSL .../install.sh | bash`, stdin is consumed by the curl data stream. The `read` call for the Telegram bot token reads nothing and the installer exits with "TELEGRAM_BOT_TOKEN is required".

## Fix

- `read -r value < /dev/tty` reads from the terminal regardless of stdin redirection
- `TELEGRAM_BOT_TOKEN=xxx curl ... | bash` skips the prompt entirely