### PR TITLE
fix: remove dead code, add shell denylist, minor cleanup

### DIFF
--- a/apps/assistant-core/src/main.ts
+++ b/apps/assistant-core/src/main.ts
@@ -5,6 +5,7 @@ import {
   probeOpencodeReachability,
 } from "@assistant-core/src/opencode-server";
 import { SqliteSessionStore } from "@assistant-core/src/session-store";
+import { sleep } from "@assistant-core/src/timers";
 import {
   formatVersionFingerprint,
   loadBuildInfo,
@@ -20,9 +21,6 @@ const WORKER_ROLE = "worker";
 const PORT_RECLAIM_TERM_TIMEOUT_MS = 4_000;
 const PORT_RECLAIM_KILL_TIMEOUT_MS = 1_500;
 const PORT_RECLAIM_POLL_INTERVAL_MS = 100;
-
-const sleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
 
 const isAddressInUseError = (error: unknown): boolean => {
   if (!error || typeof error !== "object") {
@@ -239,6 +237,10 @@ const runWorkerProcess = async (): Promise<number> => {
             systemPromptPath: config.systemPromptPath ?? undefined,
             gitIdentity: process.env.GIT_AUTHOR_NAME,
             enableShellTool: config.piAgentEnableShellTool,
+            shellCommandDenylist:
+              config.shellCommandDenylist.length > 0
+                ? config.shellCommandDenylist
+                : undefined,
           })
         : new DeterministicModelStub();
 

--- a/apps/assistant-core/src/opencode-server.ts
+++ b/apps/assistant-core/src/opencode-server.ts
@@ -1,3 +1,5 @@
+import { sleep } from "@assistant-core/src/timers";
+
 type EnsureServerOptions = {
   binaryPath: string;
   attachUrl: string;
@@ -9,9 +11,6 @@ type EnsureServerOptions = {
   spawnServer?: () => void;
   waitMs?: (ms: number) => Promise<void>;
 };
-
-const sleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
 
 export const probeOpencodeReachability = async (
   attachUrl: string,

--- a/apps/assistant-core/src/timers.ts
+++ b/apps/assistant-core/src/timers.ts
@@ -1,0 +1,4 @@
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });

--- a/apps/assistant-core/src/worker.ts
+++ b/apps/assistant-core/src/worker.ts
@@ -20,10 +20,10 @@ import {
   isSlashCommand,
 } from "@assistant-core/src/slash-commands";
 import { flushPendingStartupAck } from "@assistant-core/src/startup-ack";
+import { sleep } from "@assistant-core/src/timers";
 import { formatVersionFingerprint } from "@assistant-core/src/version";
 import { WorkerContext } from "@assistant-core/src/worker-context";
 import {
-  buildSessionKey,
   buildTopicKey,
   loadActiveWorkspace,
   setActiveWorkspace,
@@ -46,11 +46,6 @@ import type {
 } from "@assistant-core/src/worker-types";
 
 export { flushPendingStartupAck };
-
-const sleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 
 const formatTokenCount = (count: number): string => {
   if (count >= 1_000_000) {
@@ -253,7 +248,7 @@ export const handleChatMessage = async (
     return;
   }
 
-  const sessionKey = buildSessionKey(topicKey);
+  const sessionKey = topicKey;
   if (deps.sessionStore?.touchTopicWorkspace) {
     await deps.sessionStore.touchTopicWorkspace(
       topicKey,

--- a/apps/assistant-core/src/workspace.ts
+++ b/apps/assistant-core/src/workspace.ts
@@ -6,8 +6,6 @@ import type { InboundMessage } from "@delegate/domain";
 export const buildTopicKey = (message: InboundMessage): string =>
   `${message.chatId}:${message.threadId ?? "root"}`;
 
-export const buildSessionKey = (topicKey: string): string => topicKey;
-
 const rememberWorkspace = (
   ctx: WorkerContext,
   topicKey: string,

--- a/apps/assistant-core/tests/config.test.ts
+++ b/apps/assistant-core/tests/config.test.ts
@@ -153,7 +153,7 @@ describe("pi_agent API key validation", () => {
     delete process.env.GROQ_API_KEY;
 
     expect(() => loadConfig()).toThrow(
-      "Set PI_AGENT_API_KEY or GROQ_API_KEY when modelProvider is pi_agent (provider: groq).",
+      'Set piAgentApiKey (or GROQ_API_KEY env var) when model provider is "pi_agent" (provider: groq).',
     );
   });
 
@@ -164,7 +164,7 @@ describe("pi_agent API key validation", () => {
     delete process.env.OPENROUTER_API_KEY;
 
     expect(() => loadConfig()).toThrow(
-      "Set PI_AGENT_API_KEY or OPENROUTER_API_KEY when modelProvider is pi_agent (provider: openrouter).",
+      'Set piAgentApiKey (or OPENROUTER_API_KEY env var) when model provider is "pi_agent" (provider: openrouter).',
     );
   });
 
@@ -174,7 +174,7 @@ describe("pi_agent API key validation", () => {
     delete process.env.PI_AGENT_API_KEY;
 
     expect(() => loadConfig()).toThrow(
-      "Set PI_AGENT_API_KEY when modelProvider is pi_agent (provider: custom-provider).",
+      'Set piAgentApiKey when model provider is "pi_agent" (provider: custom-provider).',
     );
   });
 

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -22,5 +22,6 @@
   "opencodeAttachUrl": "http://127.0.0.1:4096",
   "opencodeAutoStart": true,
   "opencodeServeHost": "127.0.0.1",
-  "opencodeServePort": 4096
+  "opencodeServePort": 4096,
+  "shellCommandDenylist": []
 }

--- a/packages/adapters-model-pi-agent/src/index.ts
+++ b/packages/adapters-model-pi-agent/src/index.ts
@@ -57,6 +57,7 @@ export class PiAgentModelAdapter implements ModelPort {
     });
     const tools = createWorkspaceTools(this.config.workspacePath, {
       enableShellTool: this.config.enableShellTool,
+      shellCommandDenylist: this.config.shellCommandDenylist,
     });
 
     const agent = new Agent({
@@ -85,6 +86,7 @@ export class PiAgentModelAdapter implements ModelPort {
       if (cached && cached.workspacePath !== input.workspacePath) {
         const tools = createWorkspaceTools(input.workspacePath, {
           enableShellTool: this.config.enableShellTool,
+          shellCommandDenylist: this.config.shellCommandDenylist,
         });
         agent.setTools(tools);
         const systemPrompt = loadSystemPrompt({

--- a/packages/adapters-model-pi-agent/src/types.ts
+++ b/packages/adapters-model-pi-agent/src/types.ts
@@ -11,4 +11,6 @@ export type PiAgentAdapterConfig = {
   enableShellTool?: boolean;
   /** Evict cached agents after this many ms of inactivity (default: 45 min). */
   agentIdleTimeoutMs?: number;
+  /** Substring patterns to block in shell commands. A command containing any pattern is rejected. */
+  shellCommandDenylist?: string[];
 };


### PR DESCRIPTION
## Summary

Closes #39, #42, #41.

- **#39**: Remove identity wrapper `buildSessionKey()` — use `topicKey` directly at call sites
- **#42**: Dedup `sleep()` helper into shared `timers.ts`, fix user-facing error messages to use config names instead of env var names, WorkerContext JSDoc already adequate
- **#41**: Add configurable shell command denylist to `execute_shell` tool with sensible defaults (fork bombs, destructive fs ops, system commands). Includes `matchesDenylist()` with 13 new tests

## Changes

| File | Change |
|------|--------|
| `apps/assistant-core/src/workspace.ts` | Remove `buildSessionKey` |
| `apps/assistant-core/src/worker.ts` | Use `topicKey` directly, import shared `sleep` |
| `apps/assistant-core/src/timers.ts` | New shared `sleep()` utility |
| `apps/assistant-core/src/main.ts` | Import shared `sleep` |
| `apps/assistant-core/src/opencode-server.ts` | Import shared `sleep` |
| `apps/assistant-core/src/config.ts` | User-friendly error messages, `shellCommandDenylist` config |
| `apps/assistant-core/tests/config.test.ts` | Updated assertions for new message wording |
| `packages/adapters-model-pi-agent/src/types.ts` | `shellCommandDenylist?: string[]` field |
| `packages/adapters-model-pi-agent/src/tools.ts` | Default denylist, `matchesDenylist()`, denylist enforcement |
| `packages/adapters-model-pi-agent/src/index.ts` | Pass denylist config through |
| `packages/adapters-model-pi-agent/tests/tools.test.ts` | 13 new denylist tests |
| `config/config.example.json` | Document `shellCommandDenylist` |

## Verification

- `bun run verify`: all checks pass (120 tests, 0 failures)