### PR TITLE
fix: improve error handling, cost display, prompt logging, and agent caching

### DIFF
--- a/apps/assistant-core/src/messaging.ts
+++ b/apps/assistant-core/src/messaging.ts
@@ -25,13 +25,14 @@ export const sendMessage = async (
           text: outbound.text,
         };
 
+  const TELEGRAM_400_ERROR_PATTERN = "Telegram sendMessage failed: 400";
+
   try {
     await chatPort.send(payload);
   } catch (error) {
     const errorText = String(error);
     const shouldRetryWithoutThread =
-      threadId !== null &&
-      errorText.includes("Telegram sendMessage failed: 400");
+      threadId !== null && errorText.includes(TELEGRAM_400_ERROR_PATTERN);
     if (!shouldRetryWithoutThread) {
       throw error;
     }

--- a/apps/assistant-core/src/worker.ts
+++ b/apps/assistant-core/src/worker.ts
@@ -68,6 +68,9 @@ const formatCostFooter = (usage: {
   cost: number;
 }): string => {
   const totalTokens = usage.inputTokens + usage.outputTokens;
+  if (usage.cost <= 0) {
+    return `\n\n---\n💰 ${formatTokenCount(totalTokens)} tokens`;
+  }
   const costStr =
     usage.cost < 0.01
       ? `$${usage.cost.toFixed(4)}`

--- a/apps/assistant-core/tests/behaviors/cost.behavior.test.ts
+++ b/apps/assistant-core/tests/behaviors/cost.behavior.test.ts
@@ -50,4 +50,58 @@ describe("cost behaviors", () => {
     expect(replies.length).toBe(1);
     expect(replies[0]?.text).toBe("Simple answer.");
   });
+
+  test("negative cost shows only token count without dollar amount", async () => {
+    const harness = new BehaviorTestHarness({
+      modelRespondFn: async (
+        input: RespondInput,
+      ): Promise<ModelTurnResponse> => ({
+        mode: "chat_reply",
+        confidence: 1,
+        replyText: "Auto-routed answer.",
+        sessionId: input.sessionId ?? "ses-cost-neg",
+        usage: {
+          inputTokens: 500,
+          outputTokens: 734,
+          cost: -0.0835,
+        },
+      }),
+    });
+    await harness.start();
+
+    await harness.sendMessage("chat-cost-neg", "tell me something");
+
+    const replies = harness.getReplies("chat-cost-neg");
+    expect(replies.length).toBe(1);
+    expect(replies[0]?.text).toContain("Auto-routed answer.");
+    expect(replies[0]?.text).toContain("1.2k tokens");
+    expect(replies[0]?.text).not.toContain("$");
+  });
+
+  test("zero cost shows only token count without dollar amount", async () => {
+    const harness = new BehaviorTestHarness({
+      modelRespondFn: async (
+        input: RespondInput,
+      ): Promise<ModelTurnResponse> => ({
+        mode: "chat_reply",
+        confidence: 1,
+        replyText: "Free answer.",
+        sessionId: input.sessionId ?? "ses-cost-zero",
+        usage: {
+          inputTokens: 200,
+          outputTokens: 100,
+          cost: 0,
+        },
+      }),
+    });
+    await harness.start();
+
+    await harness.sendMessage("chat-cost-zero", "tell me something");
+
+    const replies = harness.getReplies("chat-cost-zero");
+    expect(replies.length).toBe(1);
+    expect(replies[0]?.text).toContain("Free answer.");
+    expect(replies[0]?.text).toContain("300 tokens");
+    expect(replies[0]?.text).not.toContain("$");
+  });
 });

--- a/packages/adapters-model-pi-agent/src/system-prompt.ts
+++ b/packages/adapters-model-pi-agent/src/system-prompt.ts
@@ -44,8 +44,10 @@ export const loadSystemPrompt = (args: {
       if (custom.length > 0) {
         return custom;
       }
-    } catch {
-      // fall through to default
+    } catch (error) {
+      console.warn(
+        `Failed to load custom system prompt from ${args.systemPromptPath}, using default: ${String(error)}`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #49, #52, #40. Partially addresses #38.

- **#52**: Guard negative/zero cost sentinels in `formatCostFooter` — show token count only when cost is meaningless (e.g., `openrouter/auto`)
- **#49**: Log warning on system prompt read failure instead of silently falling back to default
- **#40**: Cache workspace path per agent — skip redundant tool/prompt recreation. Gate idle agent eviction behind size threshold (>50) instead of running O(n) scan on every request
- **#38**: Add `onError` callback to `TopicQueue` for error surfacing, add `maxQueueSize` backpressure to `Semaphore` (default 100), extract Telegram error pattern into named constant

## Changes

| File | Change |
|------|--------|
| `apps/assistant-core/src/worker.ts` | `formatCostFooter` guards `cost <= 0` |
| `apps/assistant-core/src/concurrency.ts` | `TopicQueue.onError` callback, `Semaphore.maxQueueSize` backpressure |
| `apps/assistant-core/src/messaging.ts` | Extract `TELEGRAM_400_ERROR_PATTERN` constant |
| `packages/adapters-model-pi-agent/src/system-prompt.ts` | `console.warn()` on prompt file read failure |
| `packages/adapters-model-pi-agent/src/index.ts` | Track `workspacePath` per cached agent, conditional tool/prompt recreation, gated eviction |
| `apps/assistant-core/tests/behaviors/cost.behavior.test.ts` | 2 new tests (negative cost, zero cost) |
| `apps/assistant-core/tests/concurrency.test.ts` | 3 new tests (backpressure, default maxQueueSize, onError callback) |

## Verification

- `bun run verify`: all checks pass (110 tests, 0 failures)