### PR TITLE
fix: harden tools, typed telegram errors, regex denylist

### DIFF
--- a/apps/assistant-core/src/config.ts
+++ b/apps/assistant-core/src/config.ts
@@ -31,7 +31,6 @@ export type AppConfig = {
   maxConcurrentTopics: number;
   systemPromptPath: string | null;
   piAgentEnableShellTool: boolean;
-  shellCommandDenylist: string[];
 };
 
 type RawConfigFile = {
@@ -61,7 +60,6 @@ type RawConfigFile = {
   maxConcurrentTopics?: number;
   systemPromptPath?: string | null;
   piAgentEnableShellTool?: boolean;
-  shellCommandDenylist?: string[];
 };
 
 const defaultConfigPath = "~/.config/delegate-assistant/config.json";
@@ -305,13 +303,6 @@ export const loadConfig = (): AppConfig => {
     process.env.PI_AGENT_ENABLE_SHELL_TOOL !== undefined
       ? process.env.PI_AGENT_ENABLE_SHELL_TOOL.trim() !== "false"
       : (asOptionalBoolean(fileConfig.piAgentEnableShellTool) ?? true);
-  const shellCommandDenylist: string[] = Array.isArray(
-    fileConfig.shellCommandDenylist,
-  )
-    ? fileConfig.shellCommandDenylist.filter(
-        (item): item is string => typeof item === "string",
-      )
-    : [];
 
   if (!existsSync(assistantRepoPath)) {
     throw new Error(`Assistant repo path does not exist: ${assistantRepoPath}`);
@@ -393,6 +384,5 @@ export const loadConfig = (): AppConfig => {
     maxConcurrentTopics,
     systemPromptPath,
     piAgentEnableShellTool,
-    shellCommandDenylist,
   };
 };

--- a/apps/assistant-core/src/main.ts
+++ b/apps/assistant-core/src/main.ts
@@ -237,10 +237,6 @@ const runWorkerProcess = async (): Promise<number> => {
             systemPromptPath: config.systemPromptPath ?? undefined,
             gitIdentity: process.env.GIT_AUTHOR_NAME,
             enableShellTool: config.piAgentEnableShellTool,
-            shellCommandDenylist:
-              config.shellCommandDenylist.length > 0
-                ? config.shellCommandDenylist
-                : undefined,
           })
         : new DeterministicModelStub();
 

--- a/apps/assistant-core/tests/worker.test.ts
+++ b/apps/assistant-core/tests/worker.test.ts
@@ -9,6 +9,7 @@ import {
   WorkerContext,
 } from "@assistant-core/src/worker";
 import type { SessionStoreLike } from "@assistant-core/src/worker-types";
+import { TelegramApiError } from "@delegate/adapters-telegram";
 import type {
   InboundMessage,
   ModelTurnResponse,
@@ -42,7 +43,7 @@ class FailingChatPort extends CapturingChatPort {
 class Thread400ThenSuccessChatPort extends CapturingChatPort {
   override async send(message: OutboundMessage): Promise<void> {
     if (message.threadId) {
-      throw new Error("Telegram sendMessage failed: 400");
+      throw new TelegramApiError(400, "sendMessage");
     }
     this.sent.push(message);
   }

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -22,6 +22,5 @@
   "opencodeAttachUrl": "http://127.0.0.1:4096",
   "opencodeAutoStart": true,
   "opencodeServeHost": "127.0.0.1",
-  "opencodeServePort": 4096,
-  "shellCommandDenylist": []
+  "opencodeServePort": 4096
 }

--- a/packages/adapters-model-pi-agent/src/types.ts
+++ b/packages/adapters-model-pi-agent/src/types.ts
@@ -11,6 +11,4 @@ export type PiAgentAdapterConfig = {
   enableShellTool?: boolean;
   /** Evict cached agents after this many ms of inactivity (default: 45 min). */
   agentIdleTimeoutMs?: number;
-  /** Substring patterns to block in shell commands. A command containing any pattern is rejected. */
-  shellCommandDenylist?: string[];
 };

--- a/packages/adapters-telegram/src/index.ts
+++ b/packages/adapters-telegram/src/index.ts
@@ -21,6 +21,22 @@ type TelegramSendMessageResponse = {
   ok: boolean;
 };
 
+/**
+ * Structured error for Telegram API HTTP failures.
+ * Enables reliable error handling via `instanceof` instead of fragile string matching.
+ */
+export class TelegramApiError extends Error {
+  readonly statusCode: number;
+  readonly method: string;
+
+  constructor(statusCode: number, method: string) {
+    super(`Telegram ${method} failed: ${statusCode}`);
+    this.name = "TelegramApiError";
+    this.statusCode = statusCode;
+    this.method = method;
+  }
+}
+
 export class TelegramLongPollingAdapter implements ChatPort {
   private readonly baseUrl: string;
 
@@ -44,7 +60,7 @@ export class TelegramLongPollingAdapter implements ChatPort {
     });
 
     if (!response.ok) {
-      throw new Error(`Telegram getUpdates failed: ${response.status}`);
+      throw new TelegramApiError(response.status, "getUpdates");
     }
 
     const decoded = (await response.json()) as TelegramGetUpdatesResponse;
@@ -82,7 +98,7 @@ export class TelegramLongPollingAdapter implements ChatPort {
     });
 
     if (!response.ok) {
-      throw new Error(`Telegram sendMessage failed: ${response.status}`);
+      throw new TelegramApiError(response.status, "sendMessage");
     }
 
     const decoded = (await response.json()) as TelegramSendMessageResponse;


### PR DESCRIPTION
## Summary

Closes #47 
Closes #48
Closes #37 
Closes #58 
Closes #38.

### Security & Tool Hardening
- **#47**: Symlink traversal fix — `resolveSafePath` now uses `realpathSync` to resolve symlinks before bounds checking. Workspace root is also resolved at tool creation time (handles `/tmp` -> `/private/tmp` on macOS). ENOENT fallback resolves parent dir for `write_file` to new paths.
- **#48**: `search_files` execution timeout — 30s `Promise.race` + `proc.kill()` pattern (same as `execute_shell`).
- **#37**: Remove redundant `--include=*` from grep. Import `KnownProvider` type from `@mariozechner/pi-ai` (documents intent on the `as any` casts).

### Denylist Overhaul
- **#58**: Replace naive substring matching with regex + word boundaries. Hardcoded `SHELL_COMMAND_DENYLIST` as `{ pattern: RegExp, label: string }[]` — no longer user-configurable (removes config pipeline from 6 files). Fixes all reported false positives (`rm -rf /tmp/build`, `halt_processing`, `reboot_counter`, `chown -R user:group ./dir`, `dd if=input.txt`, `echo shutdown_mode`).

### Error Handling
- **#38**: 
  - **Part 1** (TopicQueue errors): No code changes — audit confirmed `handleChatMessage` already sends failure messages to users; `drain()` logs escaping errors.
  - **Part 2** (Semaphore backpressure): Already resolved in PR #57.
  - **Part 3** (Typed errors): New `TelegramApiError` class with `statusCode`/`method` properties. `messaging.ts` uses `instanceof` + `statusCode === 400` instead of fragile string matching.
  - **Part 4** (System prompt fallback): Already resolved in PR #57.

## Changes

| File | Change |
|------|--------|
| `packages/adapters-model-pi-agent/src/tools.ts` | Regex denylist, `realpathSync` in `resolveSafePath`, search timeout, workspace realpath, removed denylist param |
| `packages/adapters-model-pi-agent/src/types.ts` | Removed `shellCommandDenylist` field |
| `packages/adapters-model-pi-agent/src/index.ts` | `KnownProvider` cast, removed denylist pass-through |
| `packages/adapters-model-pi-agent/tests/tools.test.ts` | Regex tests, 6 false-positive regression tests, 3 symlink tests |
| `packages/adapters-telegram/src/index.ts` | `TelegramApiError` class + HTTP throw sites |
| `apps/assistant-core/src/config.ts` | Removed denylist from config pipeline |
| `apps/assistant-core/src/main.ts` | Removed denylist wiring |
| `apps/assistant-core/src/messaging.ts` | `instanceof TelegramApiError` replaces string matching |
| `apps/assistant-core/tests/worker.test.ts` | Test fake throws `TelegramApiError` |
| `config/config.example.json` | Removed `shellCommandDenylist` |

## Verification

- `bun run verify`: all checks pass (131 tests, 0 failures, 5 skipped)