### PR TITLE
feat: startup version announcement via Telegram

### DIFF
--- a/apps/assistant-core/src/config.ts
+++ b/apps/assistant-core/src/config.ts
@@ -31,6 +31,8 @@ export type AppConfig = {
   maxConcurrentTopics: number;
   systemPromptPath: string | null;
   piAgentEnableShellTool: boolean;
+  startupAnnounceChatId: string | null;
+  startupAnnounceThreadId: string | null;
 };
 
 type RawConfigFile = {
@@ -60,6 +62,8 @@ type RawConfigFile = {
   maxConcurrentTopics?: number;
   systemPromptPath?: string | null;
   piAgentEnableShellTool?: boolean;
+  startupAnnounceChatId?: string | null;
+  startupAnnounceThreadId?: string | null;
 };
 
 const defaultConfigPath = "~/.config/delegate-assistant/config.json";
@@ -184,6 +188,8 @@ export const loadConfig = (): AppConfig => {
     "MAX_CONCURRENT_TOPICS",
     "SYSTEM_PROMPT_PATH",
     "PI_AGENT_ENABLE_SHELL_TOOL",
+    "STARTUP_ANNOUNCE_CHAT_ID",
+    "STARTUP_ANNOUNCE_THREAD_ID",
   ].filter((key) => process.env[key] !== undefined).length;
 
   const port = Number(
@@ -303,6 +309,14 @@ export const loadConfig = (): AppConfig => {
     process.env.PI_AGENT_ENABLE_SHELL_TOOL !== undefined
       ? process.env.PI_AGENT_ENABLE_SHELL_TOOL.trim() !== "false"
       : (asOptionalBoolean(fileConfig.piAgentEnableShellTool) ?? true);
+  const startupAnnounceChatId =
+    process.env.STARTUP_ANNOUNCE_CHAT_ID?.trim() ||
+    asOptionalNullableString(fileConfig.startupAnnounceChatId) ||
+    null;
+  const startupAnnounceThreadId =
+    process.env.STARTUP_ANNOUNCE_THREAD_ID?.trim() ||
+    asOptionalNullableString(fileConfig.startupAnnounceThreadId) ||
+    null;
 
   if (!existsSync(assistantRepoPath)) {
     throw new Error(`Assistant repo path does not exist: ${assistantRepoPath}`);
@@ -384,5 +398,7 @@ export const loadConfig = (): AppConfig => {
     maxConcurrentTopics,
     systemPromptPath,
     piAgentEnableShellTool,
+    startupAnnounceChatId,
+    startupAnnounceThreadId,
   };
 };

--- a/apps/assistant-core/src/main.ts
+++ b/apps/assistant-core/src/main.ts
@@ -320,6 +320,8 @@ const runWorkerProcess = async (): Promise<number> => {
           defaultWorkspacePath: config.assistantRepoPath,
           stopSignal: stopController.signal,
           buildInfo,
+          startupAnnounceChatId: config.startupAnnounceChatId,
+          startupAnnounceThreadId: config.startupAnnounceThreadId,
           onRestartRequested: async () => {
             requestStop("chat_restart", true);
           },

--- a/apps/assistant-core/src/worker-types.ts
+++ b/apps/assistant-core/src/worker-types.ts
@@ -68,6 +68,8 @@ export type WorkerOptions = {
     chatId: string;
     threadId: string | null;
   }) => Promise<void> | void;
+  startupAnnounceChatId?: string | null;
+  startupAnnounceThreadId?: string | null;
 };
 
 export type LogFields = Record<string, string | number | boolean | null>;

--- a/apps/assistant-core/src/worker.ts
+++ b/apps/assistant-core/src/worker.ts
@@ -436,6 +436,33 @@ export const startTelegramWorker = (
       });
     }
 
+    if (options.startupAnnounceChatId) {
+      const version = options.buildInfo?.releaseVersion ?? "unknown";
+      try {
+        await sendMessage(
+          ctx,
+          deps.chatPort,
+          {
+            chatId: options.startupAnnounceChatId,
+            threadId: options.startupAnnounceThreadId ?? null,
+            text: `Delegate Assistant v${version} is online.`,
+          },
+          { action: "runtime", stage: "startup_announce" },
+        );
+        logInfo("startup_announce.sent", {
+          chatId: options.startupAnnounceChatId,
+          threadId: options.startupAnnounceThreadId ?? null,
+          version,
+        });
+      } catch (error) {
+        logError("startup_announce.failed", {
+          chatId: options.startupAnnounceChatId,
+          threadId: options.startupAnnounceThreadId ?? null,
+          error: String(error),
+        });
+      }
+    }
+
     if (deps.sessionStore) {
       try {
         cursor = await deps.sessionStore.getCursor();

--- a/apps/assistant-core/tests/behaviors/startup.behavior.test.ts
+++ b/apps/assistant-core/tests/behaviors/startup.behavior.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startTelegramWorker } from "@assistant-core/src/worker";
+import { SqliteSessionStore } from "@delegate/adapters-session-store-sqlite";
+import {
+  ContextAwareModel,
+  defaultBuildInfo,
+  MockChatPort,
+  waitUntil,
+} from "./test-harness";
+
+describe("startup announcement", () => {
+  test("sends version announcement when startupAnnounceChatId is configured", async () => {
+    const chatPort = new MockChatPort();
+    const model = new ContextAwareModel();
+    const tmpDir = mkdtempSync(join(tmpdir(), "delegate-startup-"));
+    const sessionStore = new SqliteSessionStore(join(tmpDir, "test.db"));
+    await sessionStore.init();
+
+    const controller = new AbortController();
+    const workerPromise = startTelegramWorker(
+      { chatPort, modelPort: model, sessionStore },
+      50,
+      {
+        stopSignal: controller.signal,
+        defaultWorkspacePath: tmpDir,
+        buildInfo: defaultBuildInfo,
+        startupAnnounceChatId: "announce-chat",
+        startupAnnounceThreadId: "42",
+      },
+    );
+
+    await waitUntil(() => chatPort.getAllReplies().length > 0, 3000);
+
+    const announcement = chatPort.getAllReplies()[0]!;
+    expect(announcement.chatId).toBe("announce-chat");
+    expect(announcement.threadId).toBe("42");
+    expect(announcement.text).toContain("v0.1.0");
+    expect(announcement.text).toContain("is online");
+
+    controller.abort();
+    await workerPromise;
+  });
+
+  test("does not send announcement when startupAnnounceChatId is null", async () => {
+    const chatPort = new MockChatPort();
+    const model = new ContextAwareModel();
+    const tmpDir = mkdtempSync(join(tmpdir(), "delegate-startup-"));
+    const sessionStore = new SqliteSessionStore(join(tmpDir, "test.db"));
+    await sessionStore.init();
+
+    // Inject a message so we know the worker has started processing
+    chatPort.injectUpdate({
+      chatId: "chat-1",
+      text: "hello",
+      receivedAt: new Date().toISOString(),
+    });
+
+    const controller = new AbortController();
+    const workerPromise = startTelegramWorker(
+      { chatPort, modelPort: model, sessionStore },
+      50,
+      {
+        stopSignal: controller.signal,
+        defaultWorkspacePath: tmpDir,
+        buildInfo: defaultBuildInfo,
+        startupAnnounceChatId: null,
+      },
+    );
+
+    await waitUntil(() => chatPort.getReplies("chat-1").length > 0, 3000);
+
+    // No announcement messages -- only the reply to "hello"
+    const allReplies = chatPort.getAllReplies();
+    const announcements = allReplies.filter((r) =>
+      r.text.includes("is online"),
+    );
+    expect(announcements).toHaveLength(0);
+
+    controller.abort();
+    await workerPromise;
+  });
+
+  test("worker continues when announcement send fails", async () => {
+    const chatPort = new MockChatPort();
+    const originalSend = chatPort.send.bind(chatPort);
+    let firstCall = true;
+    chatPort.send = async (message) => {
+      if (firstCall) {
+        firstCall = false;
+        throw new Error("Telegram API unavailable");
+      }
+      return originalSend(message);
+    };
+
+    const model = new ContextAwareModel();
+    const tmpDir = mkdtempSync(join(tmpdir(), "delegate-startup-"));
+    const sessionStore = new SqliteSessionStore(join(tmpDir, "test.db"));
+    await sessionStore.init();
+
+    chatPort.injectUpdate({
+      chatId: "chat-1",
+      text: "hello after failure",
+      receivedAt: new Date().toISOString(),
+    });
+
+    const controller = new AbortController();
+    const workerPromise = startTelegramWorker(
+      { chatPort, modelPort: model, sessionStore },
+      50,
+      {
+        stopSignal: controller.signal,
+        defaultWorkspacePath: tmpDir,
+        buildInfo: defaultBuildInfo,
+        startupAnnounceChatId: "announce-chat",
+      },
+    );
+
+    // Worker should still process messages despite announcement failure
+    await waitUntil(() => chatPort.getReplies("chat-1").length > 0, 3000);
+
+    expect(chatPort.getReplies("chat-1").length).toBeGreaterThan(0);
+
+    controller.abort();
+    await workerPromise;
+  });
+});

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -22,5 +22,7 @@
   "opencodeAttachUrl": "http://127.0.0.1:4096",
   "opencodeAutoStart": true,
   "opencodeServeHost": "127.0.0.1",
-  "opencodeServePort": 4096
+  "opencodeServePort": 4096,
+  "startupAnnounceChatId": null,
+  "startupAnnounceThreadId": null
 }


### PR DESCRIPTION
## Summary

Closes #53

On every process start, sends a one-time Telegram message to a configurable chat/topic:

> Delegate Assistant v0.3.0 is online.

Covers auto-updates (updater restarts the service) and manual restarts (`/restart`).

## Changes

| File | Change |
|------|--------|
| `apps/assistant-core/src/config.ts` | New `startupAnnounceChatId` and `startupAnnounceThreadId` fields with env var overrides |
| `apps/assistant-core/src/worker-types.ts` | Added both fields to `WorkerOptions` |
| `apps/assistant-core/src/worker.ts` | One-time announcement in `startTelegramWorker`, after startup-ack flush, before poll loop |
| `apps/assistant-core/src/main.ts` | Passes config values through to `WorkerOptions` |
| `config/config.example.json` | Documents new fields |
| `apps/assistant-core/tests/behaviors/startup.behavior.test.ts` | 3 tests: sends announcement, skips when null, worker continues on send failure |

## Configuration

```json
"startupAnnounceChatId": "-1003504827726",
"startupAnnounceThreadId": "1"
```

Both optional. If `startupAnnounceChatId` is not set, no announcement is sent.

Env var overrides: `STARTUP_ANNOUNCE_CHAT_ID`, `STARTUP_ANNOUNCE_THREAD_ID`.

## Verification

`bun run verify`: all checks pass (134 tests, 0 failures, 5 skipped).