### PR TITLE
fix: gate release workflow on CI success via workflow_run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
 
 concurrency:
   group: release
@@ -11,6 +12,7 @@ concurrency:
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -18,6 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Setup Bun
@@ -27,9 +30,6 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
-
-      - name: Verify
-        run: bun run verify
 
       - name: Compute next version
         id: version


### PR DESCRIPTION
## Summary

Prevents the Release workflow from running until the CI workflow has completed successfully.

## Changes

**`.github/workflows/release.yml`**
- Trigger changed from `push` to `main` → `workflow_run` on CI completion (main branch)
- Added `if: workflow_run.conclusion == 'success'` guard — release is skipped if CI fails
- Checkout now uses `workflow_run.head_sha` to release the exact commit CI validated
- Removed redundant `bun run verify` step (CI already runs this)

## Before

Both CI and Release workflows fired independently on push to main. A release could go out even if integration tests failed.

## After

Release only runs after CI passes. If CI fails, no release is created.