### PR TITLE
feat: add web_fetch and web_search tools with prompt injection protection

### DIFF
--- a/apps/assistant-core/src/config.ts
+++ b/apps/assistant-core/src/config.ts
@@ -31,6 +31,10 @@ export type AppConfig = {
   maxConcurrentTopics: number;
   systemPromptPath: string | null;
   piAgentEnableShellTool: boolean;
+  piAgentEnableWebFetchTool: boolean;
+  piAgentEnableWebSearchTool: boolean;
+  piAgentWebFetchProvider: string | null;
+  piAgentWebFetchModel: string | null;
   startupAnnounceChatId: string | null;
   startupAnnounceThreadId: string | null;
 };
@@ -62,6 +66,10 @@ type RawConfigFile = {
   maxConcurrentTopics?: number;
   systemPromptPath?: string | null;
   piAgentEnableShellTool?: boolean;
+  piAgentEnableWebFetchTool?: boolean;
+  piAgentEnableWebSearchTool?: boolean;
+  piAgentWebFetchProvider?: string | null;
+  piAgentWebFetchModel?: string | null;
   startupAnnounceChatId?: string | null;
   startupAnnounceThreadId?: string | null;
 };
@@ -188,6 +196,10 @@ export const loadConfig = (): AppConfig => {
     "MAX_CONCURRENT_TOPICS",
     "SYSTEM_PROMPT_PATH",
     "PI_AGENT_ENABLE_SHELL_TOOL",
+    "PI_AGENT_ENABLE_WEB_FETCH_TOOL",
+    "PI_AGENT_ENABLE_WEB_SEARCH_TOOL",
+    "PI_AGENT_WEB_FETCH_PROVIDER",
+    "PI_AGENT_WEB_FETCH_MODEL",
     "STARTUP_ANNOUNCE_CHAT_ID",
     "STARTUP_ANNOUNCE_THREAD_ID",
   ].filter((key) => process.env[key] !== undefined).length;
@@ -309,6 +321,22 @@ export const loadConfig = (): AppConfig => {
     process.env.PI_AGENT_ENABLE_SHELL_TOOL !== undefined
       ? process.env.PI_AGENT_ENABLE_SHELL_TOOL.trim() !== "false"
       : (asOptionalBoolean(fileConfig.piAgentEnableShellTool) ?? true);
+  const piAgentEnableWebFetchTool =
+    process.env.PI_AGENT_ENABLE_WEB_FETCH_TOOL !== undefined
+      ? process.env.PI_AGENT_ENABLE_WEB_FETCH_TOOL.trim() !== "false"
+      : (asOptionalBoolean(fileConfig.piAgentEnableWebFetchTool) ?? true);
+  const piAgentEnableWebSearchTool =
+    process.env.PI_AGENT_ENABLE_WEB_SEARCH_TOOL !== undefined
+      ? process.env.PI_AGENT_ENABLE_WEB_SEARCH_TOOL.trim() !== "false"
+      : (asOptionalBoolean(fileConfig.piAgentEnableWebSearchTool) ?? true);
+  const piAgentWebFetchProvider =
+    process.env.PI_AGENT_WEB_FETCH_PROVIDER?.trim() ||
+    asOptionalNullableString(fileConfig.piAgentWebFetchProvider) ||
+    null;
+  const piAgentWebFetchModel =
+    process.env.PI_AGENT_WEB_FETCH_MODEL?.trim() ||
+    asOptionalNullableString(fileConfig.piAgentWebFetchModel) ||
+    null;
   const startupAnnounceChatId =
     process.env.STARTUP_ANNOUNCE_CHAT_ID?.trim() ||
     asOptionalNullableString(fileConfig.startupAnnounceChatId) ||
@@ -398,6 +426,10 @@ export const loadConfig = (): AppConfig => {
     maxConcurrentTopics,
     systemPromptPath,
     piAgentEnableShellTool,
+    piAgentEnableWebFetchTool,
+    piAgentEnableWebSearchTool,
+    piAgentWebFetchProvider,
+    piAgentWebFetchModel,
     startupAnnounceChatId,
     startupAnnounceThreadId,
   };

--- a/apps/assistant-core/src/main.ts
+++ b/apps/assistant-core/src/main.ts
@@ -237,6 +237,10 @@ const runWorkerProcess = async (): Promise<number> => {
             systemPromptPath: config.systemPromptPath ?? undefined,
             gitIdentity: process.env.GIT_AUTHOR_NAME,
             enableShellTool: config.piAgentEnableShellTool,
+            enableWebFetchTool: config.piAgentEnableWebFetchTool,
+            enableWebSearchTool: config.piAgentEnableWebSearchTool,
+            webFetchProvider: config.piAgentWebFetchProvider ?? undefined,
+            webFetchModel: config.piAgentWebFetchModel ?? undefined,
           })
         : new DeterministicModelStub();
 

--- a/packages/adapters-model-pi-agent/src/index.ts
+++ b/packages/adapters-model-pi-agent/src/index.ts
@@ -57,6 +57,14 @@ export class PiAgentModelAdapter implements ModelPort {
     });
     const tools = createWorkspaceTools(this.config.workspacePath, {
       enableShellTool: this.config.enableShellTool,
+      enableWebFetchTool: this.config.enableWebFetchTool,
+      enableWebSearchTool: this.config.enableWebSearchTool,
+      webFetchConfig: {
+        provider: this.config.webFetchProvider ?? this.config.provider,
+        model: this.config.webFetchModel ?? this.config.model,
+        getApiKey: () => this.config.apiKey,
+        sessionKey,
+      },
     });
 
     const agent = new Agent({
@@ -85,6 +93,14 @@ export class PiAgentModelAdapter implements ModelPort {
       if (cached && cached.workspacePath !== input.workspacePath) {
         const tools = createWorkspaceTools(input.workspacePath, {
           enableShellTool: this.config.enableShellTool,
+          enableWebFetchTool: this.config.enableWebFetchTool,
+          enableWebSearchTool: this.config.enableWebSearchTool,
+          webFetchConfig: {
+            provider: this.config.webFetchProvider ?? this.config.provider,
+            model: this.config.webFetchModel ?? this.config.model,
+            getApiKey: () => this.config.apiKey,
+            sessionKey,
+          },
         });
         agent.setTools(tools);
         const systemPrompt = loadSystemPrompt({

--- a/packages/adapters-model-pi-agent/src/system-prompt.ts
+++ b/packages/adapters-model-pi-agent/src/system-prompt.ts
@@ -9,9 +9,11 @@ const DEFAULT_GIT_IDENTITY = "the delegate assistant";
 
 const buildDefaultSystemPrompt = (args: SystemPromptArgs): string => {
   const identity = args.gitIdentity?.trim() || DEFAULT_GIT_IDENTITY;
-  return `You are a personal chief of staff. Your role is to handle tasks delegated to you efficiently and proactively. You operate within a workspace at ${args.workspacePath} and have access to tools for reading files, writing files, searching, listing directories, and executing shell commands.
+  return `You are a personal chief of staff. Your role is to handle tasks delegated to you efficiently and proactively. You operate within a workspace at ${args.workspacePath} and have access to tools for reading files, writing files, searching, listing directories, executing shell commands, searching the web, and fetching web pages.
 
 You handle a wide range of tasks -- software engineering, research, analysis, drafting, planning, automation, and anything else delegated to you. Coding is one capability among many.
+
+When you need current information, facts you're unsure about, or knowledge beyond your training data, use the web_search tool to look it up. Do not say you lack access to information — you have web search. Do not apologize for not knowing something — search for it instead. Use web_fetch when you already have a specific URL to read in detail.
 
 You operate as the GitHub user "${identity}". Your git commits and pull requests are attributed to this identity.
 

--- a/packages/adapters-model-pi-agent/src/types.ts
+++ b/packages/adapters-model-pi-agent/src/types.ts
@@ -9,6 +9,14 @@ export type PiAgentAdapterConfig = {
   gitIdentity?: string;
   /** Enable the execute_shell tool (default: true). Set to false to disable arbitrary shell access. */
   enableShellTool?: boolean;
+  /** Enable the web_fetch tool (default: true). Set to false to disable web access. */
+  enableWebFetchTool?: boolean;
+  /** Enable the web_search tool (default: true). Set to false to disable web search. */
+  enableWebSearchTool?: boolean;
+  /** Provider for the web_fetch summarizer model (default: same as `provider`). */
+  webFetchProvider?: string;
+  /** Model for the web_fetch summarizer (default: same as `model`). */
+  webFetchModel?: string;
   /** Evict cached agents after this many ms of inactivity (default: 45 min). */
   agentIdleTimeoutMs?: number;
 };

--- a/packages/adapters-model-pi-agent/tests/integration.test.ts
+++ b/packages/adapters-model-pi-agent/tests/integration.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { RespondInput } from "@delegate/ports";
 import { PiAgentModelAdapter } from "../src/index";
+import { createWebFetchTool, createWebSearchTool } from "../src/tools";
 
 const SKIP = !process.env.OPENROUTER_API_KEY;
 const TIMEOUT = 30_000;
@@ -122,4 +123,212 @@ describe.skipIf(SKIP)("PiAgentModelAdapter integration", () => {
     },
     TIMEOUT,
   );
+});
+
+// ---------------------------------------------------------------------------
+// web_fetch tool — real integration test
+// ---------------------------------------------------------------------------
+
+describe.skipIf(SKIP)("web_fetch integration", () => {
+  test("fetches and summarizes a real web page", async () => {
+    const tool = createWebFetchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+      getApiKey: () => process.env.OPENROUTER_API_KEY,
+    });
+
+    const result = await tool.execute("tc-wf-integ-1", {
+      url: "https://example.com",
+      query: "What is this website about?",
+    });
+
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    // Should contain [Source: ...] prefix and some summary content
+    expect(text).toContain("[Source:");
+    expect(text).toContain("example.com");
+    expect(text.length).toBeGreaterThan(50);
+    // Should NOT contain "Error:" since example.com is a reliable endpoint
+    expect(text).not.toMatch(/^Error:/);
+  }, 60_000); // generous timeout: HTTP fetch + LLM summarization
+
+  test(
+    "returns error for unreachable host (not raw content)",
+    async () => {
+      const tool = createWebFetchTool({
+        provider: "openrouter",
+        model: "openrouter/auto",
+        getApiKey: () => process.env.OPENROUTER_API_KEY,
+      });
+
+      const result = await tool.execute("tc-wf-integ-2", {
+        url: "https://this-host-definitely-does-not-exist-xyz123.invalid",
+        query: "anything",
+      });
+
+      const text = (result.content[0] as { type: "text"; text: string }).text;
+      expect(text).toContain("Error");
+    },
+    TIMEOUT,
+  );
+
+  test("fetches and summarizes a real content-heavy page", async () => {
+    const tool = createWebFetchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+      getApiKey: () => process.env.OPENROUTER_API_KEY,
+    });
+
+    const result = await tool.execute("tc-wf-integ-wiki", {
+      url: "https://en.wikipedia.org/wiki/Ada_Lovelace",
+      query: "Who was Ada Lovelace?",
+    });
+
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).not.toMatch(/^Error:/);
+    expect(text.toLowerCase()).toContain("lovelace");
+    expect(text.toLowerCase()).toMatch(
+      /computer|programming|algorithm|mathematician/,
+    );
+    expect(text.length).toBeGreaterThan(50);
+  }, 60_000);
+
+  test("blocks SSRF to localhost", async () => {
+    const tool = createWebFetchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+      getApiKey: () => process.env.OPENROUTER_API_KEY,
+    });
+
+    const result = await tool.execute("tc-wf-integ-ssrf-localhost", {
+      url: "http://127.0.0.1:80/",
+      query: "test",
+    });
+
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Error");
+    expect(text.toLowerCase()).toContain("private");
+  }, 15_000);
+
+  test("blocks SSRF to cloud metadata endpoint", async () => {
+    const tool = createWebFetchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+      getApiKey: () => process.env.OPENROUTER_API_KEY,
+    });
+
+    const result = await tool.execute("tc-wf-integ-ssrf-metadata", {
+      url: "http://169.254.169.254/latest/meta-data/",
+      query: "credentials",
+    });
+
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Error");
+    expect(text.toLowerCase()).toContain("private");
+  }, 15_000);
+
+  test("handles non-HTML content (JSON endpoint)", async () => {
+    const tool = createWebFetchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+      getApiKey: () => process.env.OPENROUTER_API_KEY,
+    });
+
+    const result = await tool.execute("tc-wf-integ-json", {
+      url: "https://httpbin.org/json",
+      query: "What data does this endpoint return?",
+    });
+
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).not.toMatch(/^Error:/);
+    expect(text.toLowerCase()).toContain("slideshow");
+    expect(text.length).toBeGreaterThan(20);
+  }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// web_search tool — real integration test
+// ---------------------------------------------------------------------------
+
+describe.skipIf(SKIP)("web_search integration", () => {
+  test("searches and returns a summary containing expected facts", async () => {
+    const tool = createWebSearchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+      getApiKey: () => process.env.OPENROUTER_API_KEY,
+    });
+
+    const result = await tool.execute("tc-ws-integ-1", {
+      query: "capital of France",
+    });
+
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    // The summary should mention Paris
+    expect(text.toLowerCase()).toContain("paris");
+    expect(text.length).toBeGreaterThan(20);
+    // Should NOT be an error
+    expect(text).not.toMatch(/^Error:/);
+  }, 60_000);
+
+  test("returns error for nonsense query with no results", async () => {
+    const tool = createWebSearchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+      getApiKey: () => process.env.OPENROUTER_API_KEY,
+    });
+
+    const result = await tool.execute("tc-ws-integ-2", {
+      query: "xyzzy12345noresultsever98765",
+    });
+
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    // May return "no results" error or a summary acknowledging nothing was found
+    // Either is acceptable — just shouldn't crash
+    expect(text.length).toBeGreaterThan(0);
+  }, 60_000);
+
+  test("search results include source context in the summary", async () => {
+    const tool = createWebSearchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+      getApiKey: () => process.env.OPENROUTER_API_KEY,
+    });
+
+    const result = await tool.execute("tc-ws-integ-bun", {
+      query: "Bun JavaScript runtime official website",
+    });
+
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).not.toMatch(/^Error:/);
+    // Summary should reference bun.sh or Oven — domains/names only present in search results
+    expect(text.toLowerCase()).toMatch(/bun\.sh|bun runtime|oven\.sh|oven/);
+    expect(text.length).toBeGreaterThan(50);
+  }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// Agent autonomous web search — full pipeline integration test
+// ---------------------------------------------------------------------------
+
+describe.skipIf(SKIP)("agent web search integration", () => {
+  const tmpDir = mkdtempSync(join(tmpdir(), "pi-agent-websearch-integ-"));
+
+  test("agent autonomously uses web_search to answer a factual question", async () => {
+    const adapter = new PiAgentModelAdapter({
+      provider: "openrouter",
+      model: "openrouter/auto",
+      maxSteps: 15,
+      workspacePath: tmpDir,
+      enableWebSearchTool: true,
+      enableWebFetchTool: true,
+    });
+
+    const result = await adapter.respond(
+      makeInput({
+        text: "Who plays Yasmin in the HBO show Industry? Search the web to find out.",
+      }),
+    );
+
+    // The agent should use web_search and find that Marisa Abela plays Yasmin
+    expect(result.replyText.toLowerCase()).toContain("marisa abela");
+  }, 90_000); // generous: adapter overhead + search + summarize
 });

--- a/packages/adapters-model-pi-agent/tests/tools.test.ts
+++ b/packages/adapters-model-pi-agent/tests/tools.test.ts
@@ -12,13 +12,22 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   buildShellEnv,
+  checkRateLimit,
   createExecuteShellTool,
   createListDirectoryTool,
   createReadFileTool,
   createSearchFilesTool,
+  createWebFetchTool,
+  createWebSearchTool,
   createWriteFileTool,
+  isPrivateIP,
   matchesDenylist,
+  parseDuckDuckGoResults,
+  resetRateLimits,
+  resolveAndValidateHost,
   SHELL_COMMAND_DENYLIST,
+  stripHtml,
+  validateUrl,
 } from "../src/tools";
 
 let workspace: string;
@@ -376,5 +385,615 @@ describe("execute_shell denylist integration", () => {
     });
     const text = (result.content[0] as { type: "text"; text: string }).text;
     expect(text).not.toContain("blocked by denylist");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateUrl
+// ---------------------------------------------------------------------------
+
+describe("validateUrl", () => {
+  test("accepts https URLs", () => {
+    const result = validateUrl("https://example.com/path?q=1");
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.parsed.hostname).toBe("example.com");
+    }
+  });
+
+  test("accepts http URLs", () => {
+    const result = validateUrl("http://example.com");
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects file:// scheme", () => {
+    const result = validateUrl("file:///etc/passwd");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toContain("http");
+    }
+  });
+
+  test("rejects ftp:// scheme", () => {
+    const result = validateUrl("ftp://ftp.example.com/file.txt");
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects javascript: scheme", () => {
+    const result = validateUrl("javascript:alert(1)");
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects empty string", () => {
+    const result = validateUrl("");
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects non-URL strings", () => {
+    const result = validateUrl("not a url at all");
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPrivateIP
+// ---------------------------------------------------------------------------
+
+describe("isPrivateIP", () => {
+  test("blocks 127.0.0.1 (loopback)", () => {
+    expect(isPrivateIP("127.0.0.1")).toBe(true);
+  });
+
+  test("blocks 127.0.0.2 (loopback range)", () => {
+    expect(isPrivateIP("127.0.0.2")).toBe(true);
+  });
+
+  test("blocks 10.0.0.1 (RFC1918)", () => {
+    expect(isPrivateIP("10.0.0.1")).toBe(true);
+  });
+
+  test("blocks 172.16.0.1 (RFC1918)", () => {
+    expect(isPrivateIP("172.16.0.1")).toBe(true);
+  });
+
+  test("blocks 172.31.255.255 (RFC1918 upper bound)", () => {
+    expect(isPrivateIP("172.31.255.255")).toBe(true);
+  });
+
+  test("allows 172.32.0.1 (outside RFC1918 range)", () => {
+    expect(isPrivateIP("172.32.0.1")).toBe(false);
+  });
+
+  test("blocks 192.168.1.1 (RFC1918)", () => {
+    expect(isPrivateIP("192.168.1.1")).toBe(true);
+  });
+
+  test("blocks 169.254.169.254 (link-local / cloud metadata)", () => {
+    expect(isPrivateIP("169.254.169.254")).toBe(true);
+  });
+
+  test("blocks 0.0.0.0", () => {
+    expect(isPrivateIP("0.0.0.0")).toBe(true);
+  });
+
+  test("allows 8.8.8.8 (public)", () => {
+    expect(isPrivateIP("8.8.8.8")).toBe(false);
+  });
+
+  test("allows 1.1.1.1 (public)", () => {
+    expect(isPrivateIP("1.1.1.1")).toBe(false);
+  });
+
+  test("blocks ::1 (IPv6 loopback)", () => {
+    expect(isPrivateIP("::1")).toBe(true);
+  });
+
+  test("blocks :: (IPv6 unspecified)", () => {
+    expect(isPrivateIP("::")).toBe(true);
+  });
+
+  test("blocks fc00::1 (IPv6 unique local)", () => {
+    expect(isPrivateIP("fc00::1")).toBe(true);
+  });
+
+  test("blocks fd12::1 (IPv6 unique local)", () => {
+    expect(isPrivateIP("fd12::1")).toBe(true);
+  });
+
+  test("blocks fe80::1 (IPv6 link-local)", () => {
+    expect(isPrivateIP("fe80::1")).toBe(true);
+  });
+
+  test("allows 2607:f8b0:4004:800::200e (public IPv6)", () => {
+    expect(isPrivateIP("2607:f8b0:4004:800::200e")).toBe(false);
+  });
+
+  test("blocks IPv4-mapped IPv6 for private IP", () => {
+    expect(isPrivateIP("::ffff:127.0.0.1")).toBe(true);
+    expect(isPrivateIP("::ffff:10.0.0.1")).toBe(true);
+  });
+
+  test("allows IPv4-mapped IPv6 for public IP", () => {
+    expect(isPrivateIP("::ffff:8.8.8.8")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAndValidateHost
+// ---------------------------------------------------------------------------
+
+describe("resolveAndValidateHost", () => {
+  test("rejects IP literal 127.0.0.1", async () => {
+    expect(await resolveAndValidateHost("127.0.0.1")).toBeNull();
+  });
+
+  test("rejects IP literal 10.0.0.1", async () => {
+    expect(await resolveAndValidateHost("10.0.0.1")).toBeNull();
+  });
+
+  test("rejects IP literal 169.254.169.254", async () => {
+    expect(await resolveAndValidateHost("169.254.169.254")).toBeNull();
+  });
+
+  test("accepts IP literal 8.8.8.8", async () => {
+    expect(await resolveAndValidateHost("8.8.8.8")).toBe("8.8.8.8");
+  });
+
+  test("resolves example.com to a public IP", async () => {
+    const result = await resolveAndValidateHost("example.com");
+    expect(result).not.toBeNull();
+  });
+
+  test("returns null for unresolvable hostname", async () => {
+    const result = await resolveAndValidateHost(
+      "this-domain-definitely-does-not-exist-abc123xyz.invalid",
+    );
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripHtml
+// ---------------------------------------------------------------------------
+
+describe("stripHtml", () => {
+  test("removes script tags and content", () => {
+    const html = '<p>Hello</p><script>alert("xss")</script><p>World</p>';
+    const result = stripHtml(html);
+    expect(result).toContain("Hello");
+    expect(result).toContain("World");
+    expect(result).not.toContain("alert");
+    expect(result).not.toContain("script");
+  });
+
+  test("removes style tags and content", () => {
+    const html = "<p>Text</p><style>body { color: red; }</style><p>More</p>";
+    const result = stripHtml(html);
+    expect(result).toContain("Text");
+    expect(result).toContain("More");
+    expect(result).not.toContain("color");
+    expect(result).not.toContain("style");
+  });
+
+  test("removes HTML comments", () => {
+    const html = "<p>Before</p><!-- secret comment --><p>After</p>";
+    const result = stripHtml(html);
+    expect(result).toContain("Before");
+    expect(result).toContain("After");
+    expect(result).not.toContain("secret");
+  });
+
+  test("strips all HTML tags", () => {
+    const html = '<div class="main"><a href="http://test.com">Link</a></div>';
+    const result = stripHtml(html);
+    expect(result).toContain("Link");
+    expect(result).not.toContain("<div");
+    expect(result).not.toContain("<a ");
+    expect(result).not.toContain("href");
+  });
+
+  test("decodes &amp; &lt; &gt; &quot; &apos;", () => {
+    const html = "&amp; &lt; &gt; &quot; &apos;";
+    const result = stripHtml(html);
+    expect(result).toBe("& < > \" '");
+  });
+
+  test("decodes &nbsp;", () => {
+    const html = "hello&nbsp;world";
+    const result = stripHtml(html);
+    expect(result).toBe("hello world");
+  });
+
+  test("decodes decimal numeric entities", () => {
+    const html = "&#65;&#66;&#67;"; // ABC
+    expect(stripHtml(html)).toBe("ABC");
+  });
+
+  test("decodes hex numeric entities", () => {
+    const html = "&#x41;&#x42;&#x43;"; // ABC
+    expect(stripHtml(html)).toBe("ABC");
+  });
+
+  test("preserves plain text content", () => {
+    const text = "Just plain text with no HTML.";
+    expect(stripHtml(text)).toBe(text);
+  });
+
+  test("handles malformed HTML gracefully", () => {
+    const html = "<p>Unclosed tag <b>bold text <p>Another paragraph";
+    const result = stripHtml(html);
+    expect(result).toContain("Unclosed tag");
+    expect(result).toContain("bold text");
+    expect(result).toContain("Another paragraph");
+  });
+
+  test("removes script tags with whitespace before closing >", () => {
+    const html = '<p>Safe</p><script >alert("xss")</script ><p>OK</p>';
+    const result = stripHtml(html);
+    expect(result).toContain("Safe");
+    expect(result).toContain("OK");
+    expect(result).not.toContain("alert");
+  });
+
+  test("removes script tags with attributes in closing tag", () => {
+    const html = '<p>Safe</p><script>alert("xss")</script\t\n bar><p>OK</p>';
+    const result = stripHtml(html);
+    expect(result).toContain("Safe");
+    expect(result).toContain("OK");
+    expect(result).not.toContain("alert");
+  });
+
+  test("does not double-unescape &amp;lt;", () => {
+    const html = "&amp;lt;div&amp;gt;";
+    const result = stripHtml(html);
+    // Should produce &lt;div&gt; (literal text), NOT <div> (decoded twice)
+    expect(result).toBe("&lt;div&gt;");
+  });
+
+  test("collapses excessive whitespace", () => {
+    const html = "<p>  Hello  </p>  <p>  World  </p>\n\n\n\n<p>  End  </p>";
+    const result = stripHtml(html);
+    // Should not have more than 2 consecutive newlines
+    expect(result).not.toMatch(/\n{3,}/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// web_fetch tool — unit tests with mocks
+// ---------------------------------------------------------------------------
+
+describe("web_fetch tool", () => {
+  test("rejects invalid URL schemes", async () => {
+    const tool = createWebFetchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+    });
+    const result = await tool.execute("tc-wf-1", {
+      url: "file:///etc/passwd",
+      query: "contents",
+    });
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Error");
+    expect(text).toContain("http");
+  });
+
+  test("rejects javascript: scheme", async () => {
+    const tool = createWebFetchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+    });
+    const result = await tool.execute("tc-wf-2", {
+      url: "javascript:alert(1)",
+      query: "test",
+    });
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Error");
+  });
+
+  test("rejects empty URL", async () => {
+    const tool = createWebFetchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+    });
+    const result = await tool.execute("tc-wf-3", {
+      url: "",
+      query: "test",
+    });
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Error");
+  });
+
+  test("rejects URLs pointing to private IPs", async () => {
+    const tool = createWebFetchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+    });
+    const result = await tool.execute("tc-wf-4", {
+      url: "http://127.0.0.1/admin",
+      query: "admin panel",
+    });
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Error");
+    expect(text).toContain("private");
+  });
+
+  test("rejects URLs to cloud metadata endpoint", async () => {
+    const tool = createWebFetchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+    });
+    const result = await tool.execute("tc-wf-5", {
+      url: "http://169.254.169.254/latest/meta-data/",
+      query: "credentials",
+    });
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Error");
+    expect(text).toContain("private");
+  });
+
+  test("includes web_fetch in createWorkspaceTools when webFetchConfig is provided", () => {
+    // Import createWorkspaceTools to verify web_fetch is included
+    const { createWorkspaceTools } = require("../src/tools");
+    const tools = createWorkspaceTools(workspace, {
+      enableShellTool: false,
+      enableWebFetchTool: true,
+      webFetchConfig: {
+        provider: "openrouter",
+        model: "openrouter/auto",
+      },
+    });
+    const toolNames = tools.map((t: { name: string }) => t.name);
+    expect(toolNames).toContain("web_fetch");
+  });
+
+  test("excludes web_fetch when enableWebFetchTool is false", () => {
+    const { createWorkspaceTools } = require("../src/tools");
+    const tools = createWorkspaceTools(workspace, {
+      enableShellTool: false,
+      enableWebFetchTool: false,
+      webFetchConfig: {
+        provider: "openrouter",
+        model: "openrouter/auto",
+      },
+    });
+    const toolNames = tools.map((t: { name: string }) => t.name);
+    expect(toolNames).not.toContain("web_fetch");
+  });
+
+  test("excludes web_fetch when webFetchConfig is not provided", () => {
+    const { createWorkspaceTools } = require("../src/tools");
+    const tools = createWorkspaceTools(workspace, {
+      enableShellTool: false,
+      enableWebFetchTool: true,
+      // no webFetchConfig
+    });
+    const toolNames = tools.map((t: { name: string }) => t.name);
+    expect(toolNames).not.toContain("web_fetch");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkRateLimit
+// ---------------------------------------------------------------------------
+
+describe("checkRateLimit", () => {
+  beforeEach(() => {
+    resetRateLimits();
+  });
+
+  test("allows requests within limit", () => {
+    for (let i = 0; i < 10; i++) {
+      expect(checkRateLimit("session-rl-1")).toBe(true);
+    }
+  });
+
+  test("blocks the 11th request within the same minute", () => {
+    for (let i = 0; i < 10; i++) {
+      checkRateLimit("session-rl-2");
+    }
+    expect(checkRateLimit("session-rl-2")).toBe(false);
+  });
+
+  test("different session keys are independent", () => {
+    for (let i = 0; i < 10; i++) {
+      checkRateLimit("session-rl-3a");
+    }
+    // session-rl-3a is at limit
+    expect(checkRateLimit("session-rl-3a")).toBe(false);
+    // session-rl-3b is fresh
+    expect(checkRateLimit("session-rl-3b")).toBe(true);
+  });
+
+  test("allows requests when no session key is provided", () => {
+    // undefined session key = no rate limiting
+    for (let i = 0; i < 20; i++) {
+      expect(checkRateLimit(undefined)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseDuckDuckGoResults
+// ---------------------------------------------------------------------------
+
+describe("parseDuckDuckGoResults", () => {
+  // Sample HTML matching the real DDG HTML lite structure
+  const sampleDdgHtml = `
+    <div class="result results_links results_links_deep web-result ">
+      <div class="links_main links_deep result__body">
+        <h2 class="result__title">
+          <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.example.com%2Fpage1&amp;rut=abc123">Example Page One</a>
+        </h2>
+        <a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.example.com%2Fpage1&amp;rut=abc123">This is the first result snippet.</a>
+        <div class="clear"></div>
+      </div>
+    </div>
+    <div class="result results_links results_links_deep web-result ">
+      <div class="links_main links_deep result__body">
+        <h2 class="result__title">
+          <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.example.org%2Fpage2&amp;rut=def456">Example &amp; Page Two</a>
+        </h2>
+        <a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.example.org%2Fpage2&amp;rut=def456">Second result with <b>bold</b> text.</a>
+        <div class="clear"></div>
+      </div>
+    </div>
+  `;
+
+  test("extracts titles, snippets, and real URLs", () => {
+    const results = parseDuckDuckGoResults(sampleDdgHtml);
+    expect(results.length).toBe(2);
+
+    expect(results[0].title).toBe("Example Page One");
+    expect(results[0].url).toBe("https://www.example.com/page1");
+    expect(results[0].snippet).toContain("first result snippet");
+
+    expect(results[1].title).toBe("Example & Page Two");
+    expect(results[1].url).toBe("https://www.example.org/page2");
+    expect(results[1].snippet).toContain("Second result");
+    expect(results[1].snippet).toContain("bold");
+    // HTML tags should be stripped from snippet
+    expect(results[1].snippet).not.toContain("<b>");
+  });
+
+  test("returns empty array for non-DDG HTML", () => {
+    const results = parseDuckDuckGoResults(
+      "<html><body><p>Just a random page</p></body></html>",
+    );
+    expect(results.length).toBe(0);
+  });
+
+  test("handles missing snippets gracefully", () => {
+    const html = `
+      <div class="result results_links results_links_deep web-result ">
+        <div class="links_main links_deep result__body">
+          <h2 class="result__title">
+            <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com&amp;rut=xyz">No Snippet Page</a>
+          </h2>
+          <div class="clear"></div>
+        </div>
+      </div>
+    `;
+    const results = parseDuckDuckGoResults(html);
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("No Snippet Page");
+    expect(results[0].url).toBe("https://example.com");
+    expect(results[0].snippet).toBe("");
+  });
+
+  test("limits to 10 results", () => {
+    // Generate 15 result blocks
+    const blocks = Array.from(
+      { length: 15 },
+      (_, i) => `
+      <div class="result results_links results_links_deep web-result ">
+        <div class="links_main links_deep result__body">
+          <h2 class="result__title">
+            <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2F${i}&amp;rut=r${i}">Result ${i}</a>
+          </h2>
+          <a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2F${i}&amp;rut=r${i}">Snippet ${i}</a>
+          <div class="clear"></div>
+        </div>
+      </div>
+    `,
+    ).join("\n");
+    const results = parseDuckDuckGoResults(blocks);
+    expect(results.length).toBe(10);
+  });
+
+  test("decodes URL-encoded uddg parameter", () => {
+    const html = `
+      <div class="result results_links results_links_deep web-result ">
+        <div class="links_main links_deep result__body">
+          <h2 class="result__title">
+            <a rel="nofollow" class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.example.com%2Fpath%3Fq%3Dtest%26lang%3Den&amp;rut=abc">Encoded URL</a>
+          </h2>
+          <a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.example.com%2Fpath%3Fq%3Dtest%26lang%3Den&amp;rut=abc">Test snippet</a>
+          <div class="clear"></div>
+        </div>
+      </div>
+    `;
+    const results = parseDuckDuckGoResults(html);
+    expect(results.length).toBe(1);
+    expect(results[0].url).toBe("https://www.example.com/path?q=test&lang=en");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// web_search tool — unit tests
+// ---------------------------------------------------------------------------
+
+describe("web_search tool", () => {
+  test("rejects empty query", async () => {
+    const tool = createWebSearchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+    });
+    const result = await tool.execute("tc-ws-1", { query: "" });
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Error");
+    expect(text).toContain("empty");
+  });
+
+  test("rejects whitespace-only query", async () => {
+    const tool = createWebSearchTool({
+      provider: "openrouter",
+      model: "openrouter/auto",
+    });
+    const result = await tool.execute("tc-ws-2", { query: "   " });
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Error");
+    expect(text).toContain("empty");
+  });
+
+  test("includes web_search in createWorkspaceTools when enabled", () => {
+    const { createWorkspaceTools } = require("../src/tools");
+    const tools = createWorkspaceTools(workspace, {
+      enableShellTool: false,
+      enableWebSearchTool: true,
+      webFetchConfig: {
+        provider: "openrouter",
+        model: "openrouter/auto",
+      },
+    });
+    const toolNames = tools.map((t: { name: string }) => t.name);
+    expect(toolNames).toContain("web_search");
+  });
+
+  test("excludes web_search when enableWebSearchTool is false", () => {
+    const { createWorkspaceTools } = require("../src/tools");
+    const tools = createWorkspaceTools(workspace, {
+      enableShellTool: false,
+      enableWebSearchTool: false,
+      webFetchConfig: {
+        provider: "openrouter",
+        model: "openrouter/auto",
+      },
+    });
+    const toolNames = tools.map((t: { name: string }) => t.name);
+    expect(toolNames).not.toContain("web_search");
+  });
+
+  test("excludes web_search when webFetchConfig is not provided", () => {
+    const { createWorkspaceTools } = require("../src/tools");
+    const tools = createWorkspaceTools(workspace, {
+      enableShellTool: false,
+      enableWebSearchTool: true,
+    });
+    const toolNames = tools.map((t: { name: string }) => t.name);
+    expect(toolNames).not.toContain("web_search");
+  });
+
+  test("includes both web_fetch and web_search by default", () => {
+    const { createWorkspaceTools } = require("../src/tools");
+    const tools = createWorkspaceTools(workspace, {
+      enableShellTool: false,
+      webFetchConfig: {
+        provider: "openrouter",
+        model: "openrouter/auto",
+      },
+    });
+    const toolNames = tools.map((t: { name: string }) => t.name);
+    expect(toolNames).toContain("web_fetch");
+    expect(toolNames).toContain("web_search");
   });
 });


### PR DESCRIPTION
## Summary

- Adds `web_fetch` tool — fetches a URL, strips HTML, summarizes via a tool-less sub-agent to prevent prompt injection from entering the main agent context
- Adds `web_search` tool — searches DuckDuckGo HTML lite, parses results (extracting real URLs from DDG redirect params), and summarizes via the same injection-resistant sub-agent
- Updates system prompt with assertive coaching so the agent proactively searches instead of saying "I don't have access to information"

## Security (defense in depth)

| Layer | Protection |
|---|---|
| URL validation | HTTP(S)-only scheme enforcement |
| SSRF blocking | DNS pre-resolve at each redirect hop, blocks RFC1918/loopback/link-local/cloud-metadata IPs |
| Redirect safety | Max 3 hops, SSRF check on each |
| Size limits | 512KB download cap, 64KB text cap after HTML stripping |
| Content isolation | Raw web content never enters main agent context |
| Tool-less summarizer | Sub-agent has zero tools — cannot act on injected instructions |
| Rate limiting | 10 requests/min per session, sliding window, applied to both tools |

## Configuration

All enabled by default. Optional overrides:
- `PI_AGENT_ENABLE_WEB_FETCH_TOOL=true|false`
- `PI_AGENT_ENABLE_WEB_SEARCH_TOOL=true|false`
- `PI_AGENT_WEB_FETCH_PROVIDER` / `PI_AGENT_WEB_FETCH_MODEL` — separate model for the summarizer

## Test coverage

- **102 unit tests** covering: URL validation, SSRF IP blocking, DNS resolution, HTML stripping, DDG result parsing, rate limiter, tool inclusion/exclusion in createWorkspaceTools
- **11 integration tests** (require `OPENROUTER_API_KEY`): real page fetch (example.com + Wikipedia), SSRF blocking (localhost + cloud metadata), non-HTML content (httpbin JSON), search with fact verification (capital of France), search source context (Bun website), nonsense query handling, full agent autonomous search (Yasmin/Industry → Marisa Abela)

## Files changed (8)

- `packages/adapters-model-pi-agent/src/tools.ts` — core implementation (web_fetch, web_search, safeFetch, SSRF protection, HTML stripping, DDG parser, rate limiter, shared summarizer)
- `packages/adapters-model-pi-agent/src/types.ts` — config type additions
- `packages/adapters-model-pi-agent/src/index.ts` — wiring (sessionKey, enableWebSearchTool)
- `packages/adapters-model-pi-agent/src/system-prompt.ts` — tool list + coaching
- `apps/assistant-core/src/config.ts` — new config fields + env vars
- `apps/assistant-core/src/main.ts` — pass-through to adapter
- `packages/adapters-model-pi-agent/tests/tools.test.ts` — unit tests
- `packages/adapters-model-pi-agent/tests/integration.test.ts` — integration tests