### PR TITLE
feat: add per-turn observability with event persistence and dashboard

### DIFF
--- a/apps/session-manager-web/src/pages/api/sessions/[id]/turns/[turnId].ts
+++ b/apps/session-manager-web/src/pages/api/sessions/[id]/turns/[turnId].ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from "astro";
+import { getSessionStore } from "../../../../../lib/store";
+
+export const GET: APIRoute = async ({ params }) => {
+  const turnId = params.turnId ?? "";
+  const store = await getSessionStore();
+  const events = await store.getTurnEvents(turnId);
+
+  if (events.length === 0) {
+    return Response.json(
+      { ok: false, error: "turn_not_found" },
+      { status: 404 },
+    );
+  }
+
+  return Response.json({ ok: true, turnId, events });
+};

--- a/apps/session-manager-web/src/pages/api/sessions/[id]/turns/index.ts
+++ b/apps/session-manager-web/src/pages/api/sessions/[id]/turns/index.ts
@@ -1,0 +1,18 @@
+import { decodeSessionKeyId } from "@delegate/adapters-session-store-sqlite";
+import type { APIRoute } from "astro";
+import { getSessionStore } from "../../../../../lib/store";
+
+export const GET: APIRoute = async ({ params }) => {
+  const id = params.id ?? "";
+  const store = await getSessionStore();
+  const sessionKey = decodeSessionKeyId(id);
+  if (!sessionKey) {
+    return Response.json(
+      { ok: false, error: "invalid_session_id" },
+      { status: 400 },
+    );
+  }
+
+  const turns = await store.listTurns(sessionKey);
+  return Response.json({ ok: true, turns });
+};

--- a/apps/session-manager-web/src/pages/sessions/[id].astro
+++ b/apps/session-manager-web/src/pages/sessions/[id].astro
@@ -10,6 +10,15 @@ const item = await store.getSessionById(sessionId);
 if (!item) {
   return Astro.redirect("/sessions");
 }
+
+const turns = await store.listTurns(item.sessionKey);
+const turnCount = turns.length;
+const totalCost = turns.reduce((sum, t) => sum + (t.totalCost ?? 0), 0);
+const formatCost = (cost: number): string => {
+  if (cost <= 0) return "—";
+  if (cost < 0.01) return `$${cost.toFixed(4)}`;
+  return `$${cost.toFixed(2)}`;
+};
 ---
 
 <AppLayout title="Session Detail">
@@ -40,6 +49,12 @@ if (!item) {
       font-size: 13px;
       word-break: break-word;
     }
+
+    .turns-link {
+      display: inline-block;
+      margin-top: 6px;
+      font-size: 13px;
+    }
   </style>
 
   <p><a href="/sessions">Back to sessions</a></p>
@@ -67,6 +82,16 @@ if (!item) {
     <div class="row">
       <div class="label">Session Key</div>
       <div class="value">{item.sessionKey}</div>
+    </div>
+    <div class="row">
+      <div class="label">Turns</div>
+      <div>
+        {turnCount} turn{turnCount !== 1 ? "s" : ""}
+        {totalCost > 0 ? ` · ${formatCost(totalCost)} total` : ""}
+      </div>
+      <a class="turns-link" href={`/sessions/${sessionId}/turns`}>
+        View turns →
+      </a>
     </div>
   </div>
 </AppLayout>

--- a/apps/session-manager-web/src/pages/sessions/[id]/turns/[turnId].astro
+++ b/apps/session-manager-web/src/pages/sessions/[id]/turns/[turnId].astro
@@ -1,0 +1,149 @@
+---
+import AppLayout from "../../../../layouts/AppLayout.astro";
+import { getSessionStore } from "../../../../lib/store";
+
+const sessionId = Astro.params.id ?? "";
+const turnId = Astro.params.turnId ?? "";
+const store = await getSessionStore();
+const events = await store.getTurnEvents(turnId);
+
+if (events.length === 0) {
+  return Astro.redirect(`/sessions/${sessionId}/turns`);
+}
+
+const eventIcon = (eventType: string): string => {
+  switch (eventType) {
+    case "turn_started":
+      return "▶";
+    case "tool_call":
+      return "🔧";
+    case "tool_result":
+      return "📄";
+    case "step_complete":
+      return "✓";
+    case "turn_completed":
+      return "✅";
+    case "turn_failed":
+      return "❌";
+    default:
+      return "•";
+  }
+};
+
+const eventLabel = (eventType: string): string => {
+  return eventType.replace(/_/g, " ");
+};
+
+const formatTime = (iso: string): string => {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString("en-US", {
+      hour12: false,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      fractionalSecondDigits: 3,
+    });
+  } catch {
+    return iso;
+  }
+};
+---
+
+<AppLayout title="Turn Detail">
+  <style>
+    .back { margin-bottom: 12px; }
+
+    .turn-header {
+      font-family: "SF Mono", Menlo, monospace;
+      font-size: 12px;
+      color: var(--muted);
+      margin-bottom: 16px;
+    }
+
+    .timeline {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+
+    .event {
+      display: grid;
+      grid-template-columns: 80px 28px 1fr;
+      gap: 0 8px;
+      padding: 10px 0;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .event:last-child {
+      border-bottom: none;
+    }
+
+    .event-time {
+      font-family: "SF Mono", Menlo, monospace;
+      font-size: 11px;
+      color: var(--muted);
+      padding-top: 2px;
+      text-align: right;
+    }
+
+    .event-icon {
+      text-align: center;
+      font-size: 14px;
+    }
+
+    .event-body {
+      min-width: 0;
+    }
+
+    .event-type {
+      font-size: 13px;
+      font-weight: 600;
+      text-transform: capitalize;
+      margin-bottom: 6px;
+    }
+
+    .event-data {
+      background: var(--panel-muted);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 10px;
+      font-family: "SF Mono", Menlo, monospace;
+      font-size: 11px;
+      white-space: pre-wrap;
+      word-break: break-word;
+      max-height: 300px;
+      overflow-y: auto;
+    }
+
+    details > summary {
+      cursor: pointer;
+      font-size: 12px;
+      color: var(--accent);
+      margin-bottom: 4px;
+    }
+  </style>
+
+  <p class="back"><a href={`/sessions/${sessionId}/turns`}>Back to turns</a></p>
+
+  <div class="turn-header">
+    Turn {turnId}
+    &middot; {events.length} event{events.length !== 1 ? "s" : ""}
+  </div>
+
+  <div class="timeline">
+    {events.map((event) => (
+      <div class="event">
+        <div class="event-time">{formatTime(event.timestamp)}</div>
+        <div class="event-icon">{eventIcon(event.eventType)}</div>
+        <div class="event-body">
+          <div class="event-type">{eventLabel(event.eventType)}</div>
+          <details>
+            <summary>Show data</summary>
+            <div class="event-data">{JSON.stringify(event.data, null, 2)}</div>
+          </details>
+        </div>
+      </div>
+    ))}
+  </div>
+</AppLayout>

--- a/apps/session-manager-web/src/pages/sessions/[id]/turns/index.astro
+++ b/apps/session-manager-web/src/pages/sessions/[id]/turns/index.astro
@@ -1,0 +1,159 @@
+---
+import { decodeSessionKeyId } from "@delegate/adapters-session-store-sqlite";
+import AppLayout from "../../../../layouts/AppLayout.astro";
+import { formatRelativeAge } from "../../../../lib/sessions";
+import { getSessionStore } from "../../../../lib/store";
+
+const sessionId = Astro.params.id ?? "";
+const store = await getSessionStore();
+const sessionKey = decodeSessionKeyId(sessionId);
+
+if (!sessionKey) {
+  return Astro.redirect("/sessions");
+}
+
+const session = await store.getSessionById(sessionId);
+if (!session) {
+  return Astro.redirect("/sessions");
+}
+
+const turns = await store.listTurns(sessionKey);
+
+const formatDuration = (start: string, end: string): string => {
+  const ms = Date.parse(end) - Date.parse(start);
+  if (Number.isNaN(ms) || ms < 0) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  const sec = ms / 1000;
+  if (sec < 60) return `${sec.toFixed(1)}s`;
+  const min = Math.floor(sec / 60);
+  const remSec = Math.floor(sec % 60);
+  return `${min}m ${remSec}s`;
+};
+
+const formatCost = (cost: number | null): string => {
+  if (cost === null || cost === undefined) return "—";
+  if (cost < 0.01) return `$${cost.toFixed(4)}`;
+  return `$${cost.toFixed(2)}`;
+};
+
+const truncate = (text: string | null, max: number): string => {
+  if (!text) return "—";
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+};
+
+const statusLabel = (eventType: string): string => {
+  if (eventType === "turn_completed") return "completed";
+  if (eventType === "turn_failed") return "failed";
+  return "in progress";
+};
+
+const statusClass = (eventType: string): string => {
+  if (eventType === "turn_completed") return "status-ok";
+  if (eventType === "turn_failed") return "status-err";
+  return "status-pending";
+};
+---
+
+<AppLayout title="Turns">
+  <style>
+    .back { margin-bottom: 12px; }
+
+    .summary {
+      font-size: 13px;
+      color: var(--muted);
+      margin-bottom: 16px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+
+    th {
+      text-align: left;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--muted);
+      padding: 8px 10px;
+      border-bottom: 2px solid var(--line);
+      font-weight: 700;
+    }
+
+    td {
+      padding: 10px;
+      border-bottom: 1px solid var(--line);
+      vertical-align: top;
+    }
+
+    tr:hover {
+      background: var(--panel-muted);
+    }
+
+    .input-preview {
+      font-family: "SF Mono", Menlo, monospace;
+      font-size: 12px;
+      max-width: 300px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .status-ok { color: var(--accent); font-weight: 600; }
+    .status-err { color: var(--warn); font-weight: 600; }
+    .status-pending { color: var(--muted); font-weight: 600; }
+
+    .mono {
+      font-family: "SF Mono", Menlo, monospace;
+      font-size: 12px;
+    }
+
+    .empty {
+      text-align: center;
+      padding: 40px;
+      color: var(--muted);
+    }
+  </style>
+
+  <p class="back"><a href={`/sessions/${sessionId}`}>Back to session</a></p>
+
+  <div class="summary">
+    {turns.length} turn{turns.length !== 1 ? "s" : ""} for {session.topicKey}
+  </div>
+
+  {turns.length === 0 ? (
+    <div class="empty">No turns recorded yet for this session.</div>
+  ) : (
+    <table>
+      <thead>
+        <tr>
+          <th>Input</th>
+          <th>Status</th>
+          <th>Duration</th>
+          <th>Steps</th>
+          <th>Cost</th>
+          <th>Time</th>
+        </tr>
+      </thead>
+      <tbody>
+        {turns.map((turn) => (
+          <tr>
+            <td class="input-preview">
+              <a href={`/sessions/${sessionId}/turns/${turn.turnId}`}>
+                {truncate(turn.inputPreview, 60)}
+              </a>
+            </td>
+            <td class={statusClass(turn.lastEventType)}>
+              {statusLabel(turn.lastEventType)}
+            </td>
+            <td class="mono">{formatDuration(turn.startedAt, turn.endedAt)}</td>
+            <td class="mono">{turn.eventCount}</td>
+            <td class="mono">{formatCost(turn.totalCost)}</td>
+            <td>{formatRelativeAge(turn.startedAt)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )}
+</AppLayout>

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,9 @@
     },
     "packages/adapters-session-store-sqlite": {
       "name": "@delegate/adapters-session-store-sqlite",
+      "dependencies": {
+        "@delegate/domain": "workspace:*",
+      },
     },
     "packages/adapters-telegram": {
       "name": "@delegate/adapters-telegram",

--- a/packages/adapters-model-pi-agent/src/types.ts
+++ b/packages/adapters-model-pi-agent/src/types.ts
@@ -1,3 +1,5 @@
+import type { TurnEventSink } from "@delegate/ports";
+
 export type PiAgentAdapterConfig = {
   provider: string;
   model: string;
@@ -19,4 +21,6 @@ export type PiAgentAdapterConfig = {
   webFetchModel?: string;
   /** Evict cached agents after this many ms of inactivity (default: 45 min). */
   agentIdleTimeoutMs?: number;
+  /** Optional sink for emitting turn observability events. */
+  turnEventSink?: TurnEventSink;
 };

--- a/packages/adapters-session-store-sqlite/package.json
+++ b/packages/adapters-session-store-sqlite/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "test": "bun test tests/"
   },
+  "dependencies": {
+    "@delegate/domain": "workspace:*"
+  },
   "exports": {
     ".": "./src/index.ts"
   }

--- a/packages/adapters-session-store-sqlite/tests/index.test.ts
+++ b/packages/adapters-session-store-sqlite/tests/index.test.ts
@@ -81,3 +81,171 @@ describe("SqliteSessionStore admin queries", () => {
     }
   });
 });
+
+describe("SqliteSessionStore turn events", () => {
+  const sessionKey = JSON.stringify(["chat-t:root", "/repo/t"]);
+
+  test("inserts and retrieves events by turnId", async () => {
+    const { store, cleanup } = await buildStore();
+
+    try {
+      await store.insertTurnEvent({
+        turnId: "turn-1",
+        sessionKey,
+        eventType: "turn_started",
+        timestamp: "2026-02-11T01:00:00.000Z",
+        data: { inputText: "hello" },
+      });
+      await store.insertTurnEvent({
+        turnId: "turn-1",
+        sessionKey,
+        eventType: "tool_call",
+        timestamp: "2026-02-11T01:00:01.000Z",
+        data: { toolName: "execute_shell", args: { command: "ls" } },
+      });
+      await store.insertTurnEvent({
+        turnId: "turn-1",
+        sessionKey,
+        eventType: "turn_completed",
+        timestamp: "2026-02-11T01:00:02.000Z",
+        data: { totalCost: 0.05 },
+      });
+
+      const events = await store.getTurnEvents("turn-1");
+      expect(events).toHaveLength(3);
+      expect(events[0]?.eventType).toBe("turn_started");
+      expect(events[0]?.data).toEqual({ inputText: "hello" });
+      expect(events[1]?.eventType).toBe("tool_call");
+      expect(events[1]?.data).toEqual({
+        toolName: "execute_shell",
+        args: { command: "ls" },
+      });
+      expect(events[2]?.eventType).toBe("turn_completed");
+
+      // Different turnId returns empty
+      const empty = await store.getTurnEvents("turn-nonexistent");
+      expect(empty).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("lists all events for a session key", async () => {
+    const { store, cleanup } = await buildStore();
+
+    try {
+      await store.insertTurnEvent({
+        turnId: "turn-a",
+        sessionKey,
+        eventType: "turn_started",
+        timestamp: "2026-02-11T01:00:00.000Z",
+        data: { inputText: "first" },
+      });
+      await store.insertTurnEvent({
+        turnId: "turn-b",
+        sessionKey,
+        eventType: "turn_started",
+        timestamp: "2026-02-11T02:00:00.000Z",
+        data: { inputText: "second" },
+      });
+
+      const events = await store.listTurnEvents(sessionKey);
+      expect(events).toHaveLength(2);
+      expect(events[0]?.turnId).toBe("turn-a");
+      expect(events[1]?.turnId).toBe("turn-b");
+
+      // Different session key returns empty
+      const other = await store.listTurnEvents(
+        JSON.stringify(["other:root", "/other"]),
+      );
+      expect(other).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("lists turn summaries grouped by turnId", async () => {
+    const { store, cleanup } = await buildStore();
+
+    try {
+      // Turn 1: complete with cost
+      await store.insertTurnEvent({
+        turnId: "turn-1",
+        sessionKey,
+        eventType: "turn_started",
+        timestamp: "2026-02-11T01:00:00.000Z",
+        data: { inputText: "hello" },
+      });
+      await store.insertTurnEvent({
+        turnId: "turn-1",
+        sessionKey,
+        eventType: "tool_call",
+        timestamp: "2026-02-11T01:00:01.000Z",
+        data: { toolName: "shell" },
+      });
+      await store.insertTurnEvent({
+        turnId: "turn-1",
+        sessionKey,
+        eventType: "turn_completed",
+        timestamp: "2026-02-11T01:00:05.000Z",
+        data: { totalCost: 0.12 },
+      });
+
+      // Turn 2: failed
+      await store.insertTurnEvent({
+        turnId: "turn-2",
+        sessionKey,
+        eventType: "turn_started",
+        timestamp: "2026-02-11T02:00:00.000Z",
+        data: { inputText: "do something" },
+      });
+      await store.insertTurnEvent({
+        turnId: "turn-2",
+        sessionKey,
+        eventType: "turn_failed",
+        timestamp: "2026-02-11T02:00:03.000Z",
+        data: { error: "timeout" },
+      });
+
+      const turns = await store.listTurns(sessionKey);
+      expect(turns).toHaveLength(2);
+
+      // Most recent first
+      expect(turns[0]?.turnId).toBe("turn-2");
+      expect(turns[0]?.eventCount).toBe(2);
+      expect(turns[0]?.inputPreview).toBe("do something");
+      expect(turns[0]?.lastEventType).toBe("turn_failed");
+
+      expect(turns[1]?.turnId).toBe("turn-1");
+      expect(turns[1]?.eventCount).toBe(3);
+      expect(turns[1]?.inputPreview).toBe("hello");
+      expect(turns[1]?.totalCost).toBe(0.12);
+      expect(turns[1]?.lastEventType).toBe("turn_completed");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("stores unbounded data without truncation", async () => {
+    const { store, cleanup } = await buildStore();
+
+    try {
+      const largePayload = "x".repeat(100_000);
+      await store.insertTurnEvent({
+        turnId: "turn-large",
+        sessionKey,
+        eventType: "tool_result",
+        timestamp: "2026-02-11T01:00:00.000Z",
+        data: { result: largePayload },
+      });
+
+      const events = await store.getTurnEvents("turn-large");
+      expect(events).toHaveLength(1);
+      expect((events[0]?.data as { result: string }).result).toHaveLength(
+        100_000,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -23,3 +23,19 @@ export type ModelTurnResponse = {
     cost: number;
   };
 };
+
+export type TurnEventType =
+  | "turn_started"
+  | "tool_call"
+  | "tool_result"
+  | "step_complete"
+  | "turn_completed"
+  | "turn_failed";
+
+export type TurnEvent = {
+  turnId: string;
+  sessionKey: string;
+  eventType: TurnEventType;
+  timestamp: string;
+  data: Record<string, unknown>;
+};

--- a/packages/ports/src/index.ts
+++ b/packages/ports/src/index.ts
@@ -2,6 +2,7 @@ import type {
   InboundMessage,
   ModelTurnResponse,
   OutboundMessage,
+  TurnEvent,
 } from "@delegate/domain";
 
 export type ChatUpdate = {
@@ -27,4 +28,8 @@ export type RespondInput = {
 export interface ModelPort {
   respond(input: RespondInput): Promise<ModelTurnResponse>;
   ping?(): Promise<void>;
+}
+
+export interface TurnEventSink {
+  emit(event: TurnEvent): Promise<void>;
 }


### PR DESCRIPTION
## Summary

- Capture per-turn events (tool calls, results, step completions, failures) from the pi-agent adapter via a new `TurnEventSink` port, persisted to a `turn_events` SQLite table with full unbounded payloads
- Surface turn data through new JSON API routes (`/api/sessions/:id/turns`, `/api/sessions/:id/turns/:turnId`) and Astro SSR pages (turn list + detail timeline)
- Remove dead `opencode_cli` model provider and all associated config/lifecycle code; rename `opencodeSessionId` -> `sessionId` across the stack
- Add `/version` dashboard page fetching build info from assistant-core
- Fix session data loss on restart (removed `DROP TABLE IF EXISTS session_mappings` from init)
- Make CI integration job non-blocking so OpenRouter quota issues don't block merges

## Motivation

The bot was opaque -- messages went in, responses came out, with no visibility into what the model was doing (which tools it called, how many steps it took, what failed, what cost what). This adds per-session observability so you can see the full event timeline for any turn.

## Changes

### New: Turn Event System
- **Domain**: `TurnEvent` type in `packages/domain`
- **Ports**: `TurnEventSink` interface in `packages/ports`
- **Adapter**: pi-agent adapter emits events on `agent_start`, `tool_execution_start/end`, `turn_end`, `agent_end`, and failures
- **Store**: `turn_events` table with `insertTurnEvent()`, `listTurns()`, `getTurnEvents()` methods
- **Wiring**: `main.ts` creates a SQLite-backed sink, passes through worker deps

### New: Dashboard Pages
- `/sessions/:id/turns` -- chronological turn list (input preview, status, duration, steps, cost)
- `/sessions/:id/turns/:turnId` -- full event timeline with tool call args/results, per-step usage
- `/version` -- build info fetched from assistant-core health endpoint
- Session detail page updated with "View Turns" link and turn count

### Cleanup
- Removed `packages/adapters-model-opencode-cli` (dead code)
- Renamed `opencodeSessionId` -> `sessionId` everywhere
- 9 new tests for SQLite CRUD and event emission

Closes #55