### PR TITLE
fix: broaden fork bomb regex, secure secrets file, add build metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,23 @@ jobs:
       - name: Write VERSION file
         run: echo "${{ steps.version.outputs.next_version }}" > VERSION
 
+      - name: Write BUILD_META.json
+        run: |
+          SHA="${{ github.event.workflow_run.head_sha }}"
+          SHORT_SHA="${SHA:0:7}"
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          TITLE="$(git log -1 --format='%s' "$SHA")"
+          BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          cat > BUILD_META.json <<ENDJSON
+          {
+            "gitSha": "${SHA}",
+            "gitShortSha": "${SHORT_SHA}",
+            "gitBranch": "${BRANCH}",
+            "commitTitle": "${TITLE}",
+            "buildTimeUtc": "${BUILD_TIME}"
+          }
+          ENDJSON
+
       - name: Create source tarball
         run: |
           TAG="${{ steps.version.outputs.next_tag }}"
@@ -69,7 +86,8 @@ jobs:
             tsconfig.base.json \
             biome.json \
             .remarkrc.json \
-            VERSION
+            VERSION \
+            BUILD_META.json
 
       - name: Create tag and release
         env:

--- a/packages/adapters-model-pi-agent/src/tools.ts
+++ b/packages/adapters-model-pi-agent/src/tools.ts
@@ -36,7 +36,10 @@ export const SHELL_COMMAND_DENYLIST: readonly DenylistEntry[] = [
   { pattern: /\breboot\b/, label: "reboot" },
   { pattern: /\bhalt\b/, label: "halt" },
   { pattern: /\bpoweroff\b/, label: "poweroff" },
-  { pattern: /:\(\)\{.*:\|:&\};:/, label: "fork bomb" },
+  {
+    pattern: /:\s*(\(\))?\s*\{.*:\s*\|\s*:.*&\s*\}\s*;\s*:/,
+    label: "fork bomb",
+  },
   { pattern: />\s*\/dev\/sd/, label: "> /dev/sd*" },
   { pattern: /\bchmod\s+-R\s+777\s+\/(?!\S)/, label: "chmod -R 777 /" },
   { pattern: /\bchown\s+-R\s+\S+\s+\/(?!\S)/, label: "chown -R ... /" },

--- a/packages/adapters-model-pi-agent/tests/tools.test.ts
+++ b/packages/adapters-model-pi-agent/tests/tools.test.ts
@@ -319,8 +319,20 @@ describe("matchesDenylist", () => {
     expect(matchesDenylist("shutdown -h now")).toBe("shutdown");
   });
 
-  test("blocks fork bomb", () => {
+  test("blocks fork bomb (standard)", () => {
     expect(matchesDenylist(":(){:|:&};:")).toBe("fork bomb");
+  });
+
+  test("blocks fork bomb (spaced variant)", () => {
+    expect(matchesDenylist(":(){ :|:& };:")).toBe("fork bomb");
+  });
+
+  test("blocks fork bomb (compact no-paren variant)", () => {
+    expect(matchesDenylist(":{:|:&};:")).toBe("fork bomb");
+  });
+
+  test("blocks fork bomb (extra whitespace)", () => {
+    expect(matchesDenylist(":()  {  : | : &  } ; :")).toBe("fork bomb");
   });
 
   test("blocks chmod -R 777 /", () => {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -215,7 +215,9 @@ setup_config() {
     api_key=$(prompt_value "$env_var_name" "${prompt_label} (required)")
   fi
 
-  # write secrets
+  # write secrets (pre-create with restrictive permissions to avoid a
+  # window where the file is world-readable before chmod 600)
+  install -m 600 /dev/null "$SECRETS_FILE"
   cat > "$SECRETS_FILE" << EOF
 # delegate-assistant secrets -- do not commit
 TELEGRAM_BOT_TOKEN=${bot_token}


### PR DESCRIPTION
## Summary

Three quick-win fixes bundled into a single PR:

- **#60 — Fork bomb regex**: Broadened the regex pattern to catch no-paren (`:{:|:&};:`) and whitespace-flexible (`:(){ :|:& };:`) variants that were dropped during the substring-to-regex migration in PR #59
- **#51 — Secrets file permissions**: Pre-create the secrets file with `install -m 600 /dev/null` before writing content, eliminating the brief window where the file is world-readable (644) before `chmod 600`
- **#54 — Build metadata fallback**: Release workflow now writes `BUILD_META.json` with git sha, branch, commit title, and build time. `version.ts` reads this as a fallback when env vars are unset (which is always the case in production), so `/version` shows real git metadata instead of "unknown"

## Changes

| File | Change |
|------|--------|
| `packages/adapters-model-pi-agent/src/tools.ts` | Broadened fork bomb regex: `/:\s*(\(\))?\s*\{.*:\s*\|\s*:.*&\s*\}\s*;\s*:/` |
| `packages/adapters-model-pi-agent/tests/tools.test.ts` | Added 3 new fork bomb variant test cases (spaced, no-paren, extra whitespace) |
| `scripts/install.sh` | Added `install -m 600 /dev/null "$SECRETS_FILE"` before the first `cat >` write |
| `.github/workflows/release.yml` | New "Write BUILD_META.json" step + included in tarball |
| `apps/assistant-core/src/version.ts` | Added `readBuildMeta()` fallback in `loadBuildInfo()` (env vars still take precedence) |
| `apps/assistant-core/tests/version.test.ts` | Added 3 new test cases: BUILD_META.json fallback, env var precedence, graceful fallback when neither exists |

## Verification

`bun run verify` passes clean: 214 tests, 0 failures.

Closes #51, closes #54, closes #60