### PR TITLE
feat: extend updater to manage engram releases

### DIFF
--- a/deploy/update-check-delegate.sh
+++ b/deploy/update-check-delegate.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# delegate-assistant update checker
+# Called by update-check.sh orchestrator.
+
+REPO="shetty4l/delegate-assistant"
+INSTALL_BASE="${HOME}/srv/delegate-assistant"
+CURRENT_VERSION_FILE="${INSTALL_BASE}/current-version"
+LOG_FILE="${HOME}/Library/Logs/delegate-assistant-updater.log"
+MAX_VERSIONS=5
+
+log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*" >> "$LOG_FILE"; }
+
+# --- fetch latest release ---
+
+RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null) || {
+  log "ERROR: Failed to fetch latest release"
+  exit 1
+}
+
+RELEASE_TAG=$(echo "$RELEASE_JSON" | jq -r '.tag_name')
+if [ -z "$RELEASE_TAG" ] || [ "$RELEASE_TAG" = "null" ]; then
+  log "ERROR: No release tag found"
+  exit 1
+fi
+
+# --- compare versions ---
+
+CURRENT_VERSION=""
+if [ -f "$CURRENT_VERSION_FILE" ]; then
+  CURRENT_VERSION=$(cat "$CURRENT_VERSION_FILE")
+fi
+
+if [ "$RELEASE_TAG" = "$CURRENT_VERSION" ]; then
+  exit 0
+fi
+
+log "New release detected: ${RELEASE_TAG} (current: ${CURRENT_VERSION:-none})"
+
+# --- download and install ---
+
+TARBALL_URL=$(echo "$RELEASE_JSON" | jq -r '.assets[] | select(.name | startswith("delegate-assistant-")) | .browser_download_url')
+if [ -z "$TARBALL_URL" ] || [ "$TARBALL_URL" = "null" ]; then
+  log "ERROR: No tarball asset in release ${RELEASE_TAG}"
+  exit 1
+fi
+
+VERSION_DIR="${INSTALL_BASE}/${RELEASE_TAG}"
+if [ -d "$VERSION_DIR" ]; then
+  rm -rf "$VERSION_DIR"
+fi
+mkdir -p "$VERSION_DIR"
+
+TMPFILE=$(mktemp)
+curl -fsSL -o "$TMPFILE" "$TARBALL_URL" 2>/dev/null || {
+  log "ERROR: Failed to download tarball"
+  rm -f "$TMPFILE"
+  exit 1
+}
+
+tar xzf "$TMPFILE" -C "$VERSION_DIR"
+rm -f "$TMPFILE"
+log "Extracted ${RELEASE_TAG} to ${VERSION_DIR}"
+
+# --- install deps and build ---
+
+(cd "$VERSION_DIR" && bun install --frozen-lockfile 2>&1) >> "$LOG_FILE" || {
+  log "ERROR: bun install failed"
+  rm -rf "$VERSION_DIR"
+  exit 1
+}
+
+(cd "$VERSION_DIR" && bun run build:web 2>&1) >> "$LOG_FILE" || {
+  log "ERROR: build:web failed"
+  rm -rf "$VERSION_DIR"
+  exit 1
+}
+
+# --- update symlink ---
+
+rm -f "${INSTALL_BASE}/latest"
+ln -s "$VERSION_DIR" "${INSTALL_BASE}/latest"
+echo "$RELEASE_TAG" > "$CURRENT_VERSION_FILE"
+log "Updated symlink: latest -> ${RELEASE_TAG}"
+
+# --- update wrapper scripts ---
+
+DEPLOY_DIR="${INSTALL_BASE}/latest/deploy"
+
+cp "${DEPLOY_DIR}/start-assistant.sh" "${INSTALL_BASE}/start-assistant.sh"
+cp "${DEPLOY_DIR}/start-web.sh" "${INSTALL_BASE}/start-web.sh"
+cp "${DEPLOY_DIR}/update-check.sh" "${INSTALL_BASE}/update-check.sh"
+cp "${DEPLOY_DIR}/update-check-engram.sh" "${INSTALL_BASE}/update-check-engram.sh"
+cp "${DEPLOY_DIR}/update-check-delegate.sh" "${INSTALL_BASE}/update-check-delegate.sh"
+chmod +x "${INSTALL_BASE}/update-check.sh"
+chmod +x "${INSTALL_BASE}/update-check-engram.sh"
+chmod +x "${INSTALL_BASE}/update-check-delegate.sh"
+chmod +x "${INSTALL_BASE}/start-assistant.sh"
+chmod +x "${INSTALL_BASE}/start-web.sh"
+
+# --- update LaunchAgent plists ---
+
+LAUNCH_AGENTS_DIR="${HOME}/Library/LaunchAgents"
+for plist_template in "${DEPLOY_DIR}"/com.suyash.*.plist; do
+  filename=$(basename "$plist_template")
+  sed "s|\${HOME}|${HOME}|g" "$plist_template" > "${LAUNCH_AGENTS_DIR}/${filename}"
+done
+log "Updated LaunchAgent plists"
+
+# --- prune old versions ---
+
+VERSIONS=()
+for d in "${INSTALL_BASE}"/v*; do
+  [ -d "$d" ] && VERSIONS+=("$(basename "$d")")
+done
+
+IFS=$'\n' SORTED=($(printf '%s\n' "${VERSIONS[@]}" | sed 's/^v//' | sort -t. -k1,1n -k2,2n -k3,3n | sed 's/^/v/'))
+unset IFS
+
+COUNT=${#SORTED[@]}
+if [ "$COUNT" -gt "$MAX_VERSIONS" ]; then
+  REMOVE_COUNT=$((COUNT - MAX_VERSIONS))
+  for ((i = 0; i < REMOVE_COUNT; i++)); do
+    OLD="${SORTED[$i]}"
+    log "Pruning old version: ${OLD}"
+    rm -rf "${INSTALL_BASE}/${OLD}"
+  done
+fi
+
+# --- restart services ---
+
+UID_VAL=$(id -u)
+launchctl kickstart -k "gui/${UID_VAL}/com.suyash.delegate-assistant" 2>/dev/null || log "WARN: Failed to restart assistant"
+launchctl kickstart -k "gui/${UID_VAL}/com.suyash.delegate-session-manager" 2>/dev/null || log "WARN: Failed to restart session-manager"
+
+log "Update complete: ${RELEASE_TAG}"

--- a/deploy/update-check-engram.sh
+++ b/deploy/update-check-engram.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Engram update checker
+# Called by update-check.sh orchestrator.
+# Skips silently if engram is not installed.
+
+REPO="shetty4l/engram"
+INSTALL_BASE="${HOME}/srv/engram"
+BIN_DIR="${HOME}/.local/bin"
+DATA_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/engram"
+CURRENT_VERSION_FILE="${INSTALL_BASE}/current-version"
+LOG_FILE="${HOME}/Library/Logs/engram-updater.log"
+MAX_VERSIONS=5
+
+log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*" >> "$LOG_FILE"; }
+
+# --- skip if not installed ---
+
+if [ ! -d "$INSTALL_BASE" ]; then
+  exit 0
+fi
+
+# --- fetch latest release ---
+
+RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null) || {
+  log "ERROR: Failed to fetch latest release"
+  exit 1
+}
+
+RELEASE_TAG=$(echo "$RELEASE_JSON" | jq -r '.tag_name')
+if [ -z "$RELEASE_TAG" ] || [ "$RELEASE_TAG" = "null" ]; then
+  log "ERROR: No release tag found"
+  exit 1
+fi
+
+# --- compare versions ---
+
+CURRENT_VERSION=""
+if [ -f "$CURRENT_VERSION_FILE" ]; then
+  CURRENT_VERSION=$(cat "$CURRENT_VERSION_FILE")
+fi
+
+if [ "$RELEASE_TAG" = "$CURRENT_VERSION" ]; then
+  exit 0
+fi
+
+log "New release detected: ${RELEASE_TAG} (current: ${CURRENT_VERSION:-none})"
+
+# --- download and install ---
+
+TARBALL_URL=$(echo "$RELEASE_JSON" | jq -r '.assets[] | select(.name | startswith("engram-")) | .browser_download_url')
+if [ -z "$TARBALL_URL" ] || [ "$TARBALL_URL" = "null" ]; then
+  log "ERROR: No tarball asset in release ${RELEASE_TAG}"
+  exit 1
+fi
+
+VERSION_DIR="${INSTALL_BASE}/${RELEASE_TAG}"
+if [ -d "$VERSION_DIR" ]; then
+  rm -rf "$VERSION_DIR"
+fi
+mkdir -p "$VERSION_DIR"
+
+TMPFILE=$(mktemp)
+curl -fsSL -o "$TMPFILE" "$TARBALL_URL" 2>/dev/null || {
+  log "ERROR: Failed to download tarball"
+  rm -f "$TMPFILE"
+  exit 1
+}
+
+tar xzf "$TMPFILE" -C "$VERSION_DIR"
+rm -f "$TMPFILE"
+log "Extracted ${RELEASE_TAG} to ${VERSION_DIR}"
+
+# --- install deps ---
+
+(cd "$VERSION_DIR" && bun install --frozen-lockfile 2>&1) >> "$LOG_FILE" || {
+  log "ERROR: bun install failed"
+  rm -rf "$VERSION_DIR"
+  exit 1
+}
+
+# --- create CLI wrapper ---
+
+cat > "$VERSION_DIR/engram" <<'WRAPPER'
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")" && pwd)"
+exec bun run "$SCRIPT_DIR/src/cli.ts" "$@"
+WRAPPER
+chmod +x "$VERSION_DIR/engram"
+
+# --- update symlink ---
+
+rm -f "${INSTALL_BASE}/latest"
+ln -s "$VERSION_DIR" "${INSTALL_BASE}/latest"
+echo "$RELEASE_TAG" > "$CURRENT_VERSION_FILE"
+log "Updated symlink: latest -> ${RELEASE_TAG}"
+
+# --- update CLI symlink ---
+
+mkdir -p "$BIN_DIR"
+ln -sf "${INSTALL_BASE}/latest/engram" "${BIN_DIR}/engram"
+
+# --- prune old versions ---
+
+VERSIONS=()
+for d in "${INSTALL_BASE}"/v*; do
+  [ -d "$d" ] && VERSIONS+=("$(basename "$d")")
+done
+
+if [ ${#VERSIONS[@]} -gt 0 ]; then
+  IFS=$'\n' SORTED=($(printf '%s\n' "${VERSIONS[@]}" | sed 's/^v//' | sort -t. -k1,1n -k2,2n -k3,3n | sed 's/^/v/'))
+  unset IFS
+
+  COUNT=${#SORTED[@]}
+  if [ "$COUNT" -gt "$MAX_VERSIONS" ]; then
+    REMOVE_COUNT=$((COUNT - MAX_VERSIONS))
+    for ((i = 0; i < REMOVE_COUNT; i++)); do
+      OLD="${SORTED[$i]}"
+      log "Pruning old version: ${OLD}"
+      rm -rf "${INSTALL_BASE}/${OLD}"
+    done
+  fi
+fi
+
+# --- restart daemon if running ---
+
+PID_FILE="${DATA_DIR}/engram.pid"
+if [ -f "$PID_FILE" ]; then
+  PID=$(cat "$PID_FILE" 2>/dev/null)
+  if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
+    log "Stopping engram daemon (PID: ${PID})..."
+    kill "$PID" 2>/dev/null || true
+    # Wait up to 5 seconds for graceful shutdown
+    for ((i = 0; i < 50; i++)); do
+      kill -0 "$PID" 2>/dev/null || break
+      sleep 0.1
+    done
+    # Force kill if still running
+    if kill -0 "$PID" 2>/dev/null; then
+      kill -9 "$PID" 2>/dev/null || true
+    fi
+    log "Engram daemon stopped"
+  fi
+  rm -f "$PID_FILE"
+fi
+
+log "Update complete: ${RELEASE_TAG}"

--- a/deploy/update-check.sh
+++ b/deploy/update-check.sh
@@ -1,132 +1,17 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
-# delegate-assistant update checker
+# Update orchestrator
 # Runs periodically via LaunchAgent to pull new releases.
+# Calls individual update scripts — failure in one does not block the other.
 
-REPO="shetty4l/delegate-assistant"
-INSTALL_BASE="${HOME}/srv/delegate-assistant"
-CURRENT_VERSION_FILE="${INSTALL_BASE}/current-version"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG_FILE="${HOME}/Library/Logs/delegate-assistant-updater.log"
-MAX_VERSIONS=5
 
 log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*" >> "$LOG_FILE"; }
 
-# --- fetch latest release ---
+# Update engram first (dependency of delegate-assistant)
+"$SCRIPT_DIR/update-check-engram.sh" || log "WARN: engram update check failed"
 
-RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null) || {
-  log "ERROR: Failed to fetch latest release"
-  exit 1
-}
-
-RELEASE_TAG=$(echo "$RELEASE_JSON" | jq -r '.tag_name')
-if [ -z "$RELEASE_TAG" ] || [ "$RELEASE_TAG" = "null" ]; then
-  log "ERROR: No release tag found"
-  exit 1
-fi
-
-# --- compare versions ---
-
-CURRENT_VERSION=""
-if [ -f "$CURRENT_VERSION_FILE" ]; then
-  CURRENT_VERSION=$(cat "$CURRENT_VERSION_FILE")
-fi
-
-if [ "$RELEASE_TAG" = "$CURRENT_VERSION" ]; then
-  exit 0
-fi
-
-log "New release detected: ${RELEASE_TAG} (current: ${CURRENT_VERSION:-none})"
-
-# --- download and install ---
-
-TARBALL_URL=$(echo "$RELEASE_JSON" | jq -r '.assets[] | select(.name | startswith("delegate-assistant-")) | .browser_download_url')
-if [ -z "$TARBALL_URL" ] || [ "$TARBALL_URL" = "null" ]; then
-  log "ERROR: No tarball asset in release ${RELEASE_TAG}"
-  exit 1
-fi
-
-VERSION_DIR="${INSTALL_BASE}/${RELEASE_TAG}"
-if [ -d "$VERSION_DIR" ]; then
-  rm -rf "$VERSION_DIR"
-fi
-mkdir -p "$VERSION_DIR"
-
-TMPFILE=$(mktemp)
-curl -fsSL -o "$TMPFILE" "$TARBALL_URL" 2>/dev/null || {
-  log "ERROR: Failed to download tarball"
-  rm -f "$TMPFILE"
-  exit 1
-}
-
-tar xzf "$TMPFILE" -C "$VERSION_DIR"
-rm -f "$TMPFILE"
-log "Extracted ${RELEASE_TAG} to ${VERSION_DIR}"
-
-# --- install deps and build ---
-
-(cd "$VERSION_DIR" && bun install --frozen-lockfile 2>&1) >> "$LOG_FILE" || {
-  log "ERROR: bun install failed"
-  rm -rf "$VERSION_DIR"
-  exit 1
-}
-
-(cd "$VERSION_DIR" && bun run build:web 2>&1) >> "$LOG_FILE" || {
-  log "ERROR: build:web failed"
-  rm -rf "$VERSION_DIR"
-  exit 1
-}
-
-# --- update symlink ---
-
-rm -f "${INSTALL_BASE}/latest"
-ln -s "$VERSION_DIR" "${INSTALL_BASE}/latest"
-echo "$RELEASE_TAG" > "$CURRENT_VERSION_FILE"
-log "Updated symlink: latest -> ${RELEASE_TAG}"
-
-# --- update wrapper scripts ---
-
-cp "${INSTALL_BASE}/latest/deploy/start-assistant.sh" "${INSTALL_BASE}/start-assistant.sh"
-cp "${INSTALL_BASE}/latest/deploy/start-web.sh" "${INSTALL_BASE}/start-web.sh"
-cp "${INSTALL_BASE}/latest/deploy/update-check.sh" "${INSTALL_BASE}/update-check.sh"
-chmod +x "${INSTALL_BASE}/start-assistant.sh"
-chmod +x "${INSTALL_BASE}/start-web.sh"
-chmod +x "${INSTALL_BASE}/update-check.sh"
-
-# --- update LaunchAgent plists ---
-
-DEPLOY_DIR="${INSTALL_BASE}/latest/deploy"
-LAUNCH_AGENTS_DIR="${HOME}/Library/LaunchAgents"
-for plist_template in "${DEPLOY_DIR}"/com.suyash.*.plist; do
-  filename=$(basename "$plist_template")
-  sed "s|\${HOME}|${HOME}|g" "$plist_template" > "${LAUNCH_AGENTS_DIR}/${filename}"
-done
-log "Updated LaunchAgent plists"
-
-# --- prune old versions ---
-
-VERSIONS=()
-for d in "${INSTALL_BASE}"/v*; do
-  [ -d "$d" ] && VERSIONS+=("$(basename "$d")")
-done
-
-IFS=$'\n' SORTED=($(printf '%s\n' "${VERSIONS[@]}" | sed 's/^v//' | sort -t. -k1,1n -k2,2n -k3,3n | sed 's/^/v/'))
-unset IFS
-
-COUNT=${#SORTED[@]}
-if [ "$COUNT" -gt "$MAX_VERSIONS" ]; then
-  REMOVE_COUNT=$((COUNT - MAX_VERSIONS))
-  for ((i = 0; i < REMOVE_COUNT; i++)); do
-    OLD="${SORTED[$i]}"
-    log "Pruning old version: ${OLD}"
-    rm -rf "${INSTALL_BASE}/${OLD}"
-  done
-fi
-
-# --- restart services ---
-
-UID_VAL=$(id -u)
-launchctl kickstart -k "gui/${UID_VAL}/com.suyash.delegate-assistant" 2>/dev/null || log "WARN: Failed to restart assistant"
-launchctl kickstart -k "gui/${UID_VAL}/com.suyash.delegate-session-manager" 2>/dev/null || log "WARN: Failed to restart session-manager"
-
-log "Update complete: ${RELEASE_TAG}"
+# Update delegate-assistant
+"$SCRIPT_DIR/update-check-delegate.sh" || log "WARN: delegate-assistant update check failed"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -284,9 +284,13 @@ install_wrapper_scripts() {
   cp "${INSTALL_BASE}/latest/deploy/start-assistant.sh" "${INSTALL_BASE}/start-assistant.sh"
   cp "${INSTALL_BASE}/latest/deploy/start-web.sh" "${INSTALL_BASE}/start-web.sh"
   cp "${INSTALL_BASE}/latest/deploy/update-check.sh" "${INSTALL_BASE}/update-check.sh"
+  cp "${INSTALL_BASE}/latest/deploy/update-check-engram.sh" "${INSTALL_BASE}/update-check-engram.sh"
+  cp "${INSTALL_BASE}/latest/deploy/update-check-delegate.sh" "${INSTALL_BASE}/update-check-delegate.sh"
   chmod +x "${INSTALL_BASE}/start-assistant.sh"
   chmod +x "${INSTALL_BASE}/start-web.sh"
   chmod +x "${INSTALL_BASE}/update-check.sh"
+  chmod +x "${INSTALL_BASE}/update-check-engram.sh"
+  chmod +x "${INSTALL_BASE}/update-check-delegate.sh"
 
   ok "Wrapper scripts installed"
 }


### PR DESCRIPTION
## Summary

Split the monolithic `update-check.sh` into three scripts for independent evolution:

- **`deploy/update-check.sh`** — Slim orchestrator that calls engram then delegate-assistant updaters in sequence. Failure in one does not block the other.
- **`deploy/update-check-engram.sh`** — Self-contained engram updater. Skips silently if engram is not installed (`~/srv/engram` doesn't exist). Handles: tarball download, `bun install`, CLI wrapper creation (with symlink resolution fix), `latest` symlink, `~/.local/bin/engram` symlink, version pruning, and daemon restart if running.
- **`deploy/update-check-delegate.sh`** — Extracted from the original `update-check.sh`, unchanged logic. Updated self-copy block to also copy the two new scripts.

Also updates `scripts/install.sh` to copy the new updater scripts to the install base during initial installation.

## Context

Engram now has automated GitHub releases ([shetty4l/engram#9](https://github.com/shetty4l/engram/pull/9)). With the upcoming engram integration ([#70](https://github.com/shetty4l/delegate-assistant/issues/70)), delegate-assistant will depend on engram at runtime. The consumer (delegate-assistant) owns keeping its dependency (engram) up to date.

## Design Decisions

- **Engram updates first** — since delegate-assistant depends on engram, update the dependency before the consumer
- **Skip if not installed** — the updater only manages updates, not initial installation. Users run engram's `curl | bash` installer separately
- **Separate log files** — engram logs to `~/Library/Logs/engram-updater.log`, delegate-assistant to its existing log file
- **Daemon restart** — if engram's HTTP daemon is running (PID file exists), send SIGTERM and clean up. Next invocation picks up the new version via the `latest` symlink
- **No LaunchAgent changes** — the existing plist still calls `update-check.sh`, which now delegates

## Files Changed

| File | Change |
|---|---|
| `deploy/update-check.sh` | Rewritten as orchestrator (~15 lines) |
| `deploy/update-check-engram.sh` | New — engram updater (~140 lines) |
| `deploy/update-check-delegate.sh` | New — extracted delegate-assistant updater (~130 lines) |
| `scripts/install.sh` | Copy new updater scripts during initial install |