### PR TITLE
fix: switch default model to Groq, fix session key parsing, add model validation

### DIFF
--- a/apps/assistant-core/src/config.ts
+++ b/apps/assistant-core/src/config.ts
@@ -256,11 +256,11 @@ export const loadConfig = (): AppConfig => {
   const piAgentProvider =
     process.env.PI_AGENT_PROVIDER?.trim() ||
     asOptionalString(fileConfig.piAgentProvider) ||
-    "openrouter";
+    "groq";
   const piAgentModel =
     process.env.PI_AGENT_MODEL?.trim() ||
     asOptionalString(fileConfig.piAgentModel) ||
-    "openrouter/auto";
+    "llama-3.3-70b-versatile";
   const piAgentApiKey =
     process.env.PI_AGENT_API_KEY?.trim() ||
     asOptionalNullableString(fileConfig.piAgentApiKey) ||

--- a/apps/assistant-core/tests/config.test.ts
+++ b/apps/assistant-core/tests/config.test.ts
@@ -79,9 +79,9 @@ describe("pi_agent API key validation", () => {
     expect(config.modelProvider).toBe("pi_agent");
   });
 
-  test("accepts OPENROUTER_API_KEY for openrouter provider (default)", () => {
+  test("accepts OPENROUTER_API_KEY for openrouter provider", () => {
     envSnap = saveEnv();
-    writeConfig(minimalConfig());
+    writeConfig(minimalConfig({ piAgentProvider: "openrouter" }));
     delete process.env.PI_AGENT_API_KEY;
     process.env.OPENROUTER_API_KEY = "sk-or-test";
 
@@ -159,7 +159,7 @@ describe("pi_agent API key validation", () => {
 
   test("throws with helpful message for openrouter when no key is set", () => {
     envSnap = saveEnv();
-    writeConfig(minimalConfig());
+    writeConfig(minimalConfig({ piAgentProvider: "openrouter" }));
     delete process.env.PI_AGENT_API_KEY;
     delete process.env.OPENROUTER_API_KEY;
 
@@ -190,22 +190,22 @@ describe("pi_agent API key validation", () => {
 });
 
 describe("pi_agent default values", () => {
-  test("defaults piAgentProvider to openrouter", () => {
+  test("defaults piAgentProvider to groq", () => {
     envSnap = saveEnv();
     writeConfig(minimalConfig());
     process.env.PI_AGENT_API_KEY = "sk-test";
 
     const config = loadConfig();
-    expect(config.piAgentProvider).toBe("openrouter");
+    expect(config.piAgentProvider).toBe("groq");
   });
 
-  test("defaults piAgentModel to openrouter/auto", () => {
+  test("defaults piAgentModel to llama-3.3-70b-versatile", () => {
     envSnap = saveEnv();
     writeConfig(minimalConfig());
     process.env.PI_AGENT_API_KEY = "sk-test";
 
     const config = loadConfig();
-    expect(config.piAgentModel).toBe("openrouter/auto");
+    expect(config.piAgentModel).toBe("llama-3.3-70b-versatile");
   });
 
   test("config file overrides defaults", () => {

--- a/packages/adapters-model-pi-agent/src/index.ts
+++ b/packages/adapters-model-pi-agent/src/index.ts
@@ -53,6 +53,12 @@ export class PiAgentModelAdapter implements ModelPort {
     // specific literal types from its KnownProvider + model-id generic params.
     const provider: KnownProvider = this.config.provider as KnownProvider;
     const model = getModel(provider as any, this.config.model as any);
+    if (!model) {
+      throw new Error(
+        `Model "${this.config.model}" not found in provider "${this.config.provider}" registry. ` +
+          `Check that piAgentProvider and piAgentModel are valid in your config.`,
+      );
+    }
     const systemPrompt = loadSystemPrompt({
       workspacePath: this.config.workspacePath,
       systemPromptPath: this.config.systemPromptPath,
@@ -328,13 +334,16 @@ export class PiAgentModelAdapter implements ModelPort {
   }
 
   async ping(): Promise<void> {
-    // Verify we can resolve the model
-    try {
-      getModel(this.config.provider as any, this.config.model as any);
-    } catch (err) {
-      throw new Error(`Pi Agent configuration error: ${String(err)}`, {
-        cause: err,
-      });
+    // Verify we can resolve the model — getModel() returns undefined on miss
+    const model = getModel(
+      this.config.provider as any,
+      this.config.model as any,
+    );
+    if (!model) {
+      throw new Error(
+        `Pi Agent configuration error: Model "${this.config.model}" not found in provider "${this.config.provider}" registry. ` +
+          `Check that piAgentProvider and piAgentModel are valid in your config.`,
+      );
     }
   }
 

--- a/packages/adapters-session-store-sqlite/tests/index.test.ts
+++ b/packages/adapters-session-store-sqlite/tests/index.test.ts
@@ -28,17 +28,27 @@ describe("SqliteSessionStore admin queries", () => {
 
     try {
       await store.upsertSession({
-        sessionKey: JSON.stringify(["chat-a:root", "/repo/a"]),
+        sessionKey: "chat-a:root",
         sessionId: "ses-a",
         status: "active",
         lastUsedAt: "2026-02-08T01:00:00.000Z",
       });
+      await store.setTopicWorkspace(
+        "chat-a:root",
+        "/repo/a",
+        "2026-02-08T01:00:00.000Z",
+      );
       await store.upsertSession({
-        sessionKey: JSON.stringify(["chat-b:42", "/repo/b"]),
+        sessionKey: "chat-b:42",
         sessionId: "ses-b",
         status: "stale",
         lastUsedAt: "2026-02-08T02:00:00.000Z",
       });
+      await store.setTopicWorkspace(
+        "chat-b:42",
+        "/repo/b",
+        "2026-02-08T02:00:00.000Z",
+      );
 
       const all = await store.listSessions({ page: 1, pageSize: 25 });
       expect(all.total).toBe(2);
@@ -61,13 +71,18 @@ describe("SqliteSessionStore admin queries", () => {
     const { store, cleanup } = await buildStore();
 
     try {
-      const sessionKey = JSON.stringify(["chat-c:root", "/repo/c"]);
+      const sessionKey = "chat-c:root";
       await store.upsertSession({
         sessionKey,
         sessionId: "ses-c",
         status: "active",
         lastUsedAt: "2026-02-08T03:00:00.000Z",
       });
+      await store.setTopicWorkspace(
+        sessionKey,
+        "/repo/c",
+        "2026-02-08T03:00:00.000Z",
+      );
 
       const id = encodeSessionKeyId(sessionKey);
       const decoded = decodeSessionKeyId(id);
@@ -83,7 +98,7 @@ describe("SqliteSessionStore admin queries", () => {
 });
 
 describe("SqliteSessionStore turn events", () => {
-  const sessionKey = JSON.stringify(["chat-t:root", "/repo/t"]);
+  const sessionKey = "chat-t:root";
 
   test("inserts and retrieves events by turnId", async () => {
     const { store, cleanup } = await buildStore();
@@ -155,9 +170,7 @@ describe("SqliteSessionStore turn events", () => {
       expect(events[1]?.turnId).toBe("turn-b");
 
       // Different session key returns empty
-      const other = await store.listTurnEvents(
-        JSON.stringify(["other:root", "/other"]),
-      );
+      const other = await store.listTurnEvents("other:root");
       expect(other).toHaveLength(0);
     } finally {
       await cleanup();


### PR DESCRIPTION
## Summary

- **Default model → Groq**: Changed default provider from `openrouter` to `groq` with `llama-3.3-70b-versatile`. OpenRouter free models (`:free` suffix) require a privacy opt-in ("allow prompts for training") at the account level — Groq's free tier has no such requirement.
- **Model validation guard**: `PiAgentModelAdapter` now throws a descriptive error (`Model "X" not found in provider "Y" registry`) when `getModel()` returns `undefined`, instead of silently passing `undefined` through to the agent which later throws a cryptic "No model configured".
- **Session key fix**: Rewrote `getSessionById()` and `listSessions()` queries to use `LEFT JOIN topic_workspace_bindings` instead of `json_extract()` on session keys. Session keys are plain strings like `"chatId:threadId"`, not JSON arrays — `json_extract` was returning `null` for every session, causing all sessions to display as "unknown / root".
- **Install script**: Default provider prompt now defaults to `groq`, openrouter fallback reverted to `openrouter/auto`, startup announcement config prompts added.

## Files Changed

| File | Change |
|------|--------|
| `apps/assistant-core/src/config.ts` | Default provider: `groq`, default model: `llama-3.3-70b-versatile` |
| `apps/assistant-core/tests/config.test.ts` | Updated assertions for new defaults |
| `packages/adapters-model-pi-agent/src/index.ts` | Model guard after `getModel()`, fixed `ping()` |
| `packages/adapters-session-store-sqlite/src/index.ts` | `LEFT JOIN` queries replacing `json_extract` |
| `packages/adapters-session-store-sqlite/tests/index.test.ts` | Plain string session keys + `setTopicWorkspace()` |
| `scripts/install.sh` | Groq default, openrouter/auto fallback, announce prompts |

## Verification

`bun run verify` passes: 257 tests, typecheck, lint, format, build, docs all clean.

## Post-Merge Action Required

After deploy, manually update mac-mini config:
- Add `GROQ_API_KEY` to `~/.config/delegate-assistant/secrets.env`
- Update `piAgentProvider` and `piAgentModel` in `~/.config/delegate-assistant/config.json`