### PR TITLE
fix: switch default Groq model to qwen/qwen3-32b

### DIFF
--- a/apps/assistant-core/src/config.ts
+++ b/apps/assistant-core/src/config.ts
@@ -260,7 +260,7 @@ export const loadConfig = (): AppConfig => {
   const piAgentModel =
     process.env.PI_AGENT_MODEL?.trim() ||
     asOptionalString(fileConfig.piAgentModel) ||
-    "llama-3.3-70b-versatile";
+    "qwen/qwen3-32b";
   const piAgentApiKey =
     process.env.PI_AGENT_API_KEY?.trim() ||
     asOptionalNullableString(fileConfig.piAgentApiKey) ||

--- a/apps/assistant-core/tests/config.test.ts
+++ b/apps/assistant-core/tests/config.test.ts
@@ -199,13 +199,13 @@ describe("pi_agent default values", () => {
     expect(config.piAgentProvider).toBe("groq");
   });
 
-  test("defaults piAgentModel to llama-3.3-70b-versatile", () => {
+  test("defaults piAgentModel to qwen/qwen3-32b", () => {
     envSnap = saveEnv();
     writeConfig(minimalConfig());
     process.env.PI_AGENT_API_KEY = "sk-test";
 
     const config = loadConfig();
-    expect(config.piAgentModel).toBe("llama-3.3-70b-versatile");
+    expect(config.piAgentModel).toBe("qwen/qwen3-32b");
   });
 
   test("config file overrides defaults", () => {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -154,12 +154,12 @@ provider_env_var() {
 provider_default_model() {
   case "$1" in
     openrouter) echo "openrouter/auto" ;;
-    groq)       echo "llama-3.3-70b-versatile" ;;
+    groq)       echo "qwen/qwen3-32b" ;;
     google)     echo "gemini-2.5-flash" ;;
     openai)     echo "gpt-4o-mini" ;;
     anthropic)  echo "claude-sonnet-4-20250514" ;;
     cerebras)   echo "llama-3.3-70b" ;;
-    *)          echo "llama-3.3-70b-versatile" ;;
+    *)          echo "qwen/qwen3-32b" ;;
   esac
 }
 


### PR DESCRIPTION
## Summary

- Switch default Groq model from `llama-3.3-70b-versatile` to `qwen/qwen3-32b`
- `llama-3.3-70b-versatile` has unreliable tool calling on Groq — their server-side validation intermittently rejects tool calls with `failed_generation` and `tool call validation failed` errors
- `qwen/qwen3-32b` handles tool calling reliably on Groq's free tier (32B reasoning model with good tool-use support)
- Already proven working on the mac-mini deployment

## Files Changed

| File | Change |
|------|--------|
| `apps/assistant-core/src/config.ts` | Default model: `qwen/qwen3-32b` |
| `scripts/install.sh` | Groq + wildcard defaults: `qwen/qwen3-32b` |
| `apps/assistant-core/tests/config.test.ts` | Updated default model assertion |

## Verification

`bun run verify` passes: 257 tests, all checks green.