### PR TITLE
fix: chunk long messages instead of truncating

### DIFF
--- a/apps/assistant-core/src/chunking.ts
+++ b/apps/assistant-core/src/chunking.ts
@@ -1,0 +1,209 @@
+/**
+ * Markdown-aware message chunking for Telegram's 4096-char limit.
+ *
+ * Splits text into chunks that each fit within maxLength, preserving
+ * markdown structure (paragraphs, code fences). Code blocks are
+ * closed/reopened at chunk boundaries so each chunk is valid markdown.
+ */
+
+const DEFAULT_MAX_LENGTH = 4096;
+
+/**
+ * Reserve space for the part indicator suffix " (1/10)" etc.
+ * Worst case: " (XX/XX)" = 8 chars. We reserve 10 for safety.
+ */
+const PART_INDICATOR_RESERVE = 10;
+
+/**
+ * Split text into chunks that each fit within maxLength characters.
+ *
+ * Splitting priority (highest to lowest):
+ * 1. Paragraph boundary (double newline)
+ * 2. Line boundary (single newline) — never inside a code fence mid-line
+ * 3. Hard cut at maxLength (last resort)
+ *
+ * Code fences (```) are tracked. If a chunk ends inside a code block,
+ * the fence is closed at the end of that chunk and reopened (with the
+ * original language tag) at the start of the next chunk.
+ */
+export const splitMessage = (
+  text: string,
+  maxLength: number = DEFAULT_MAX_LENGTH,
+): string[] => {
+  if (text.length <= maxLength) {
+    return [text];
+  }
+
+  const effectiveMax = maxLength - PART_INDICATOR_RESERVE;
+  const chunks: string[] = [];
+  let remaining = text;
+
+  // Track whether we're inside a code fence and its language tag.
+  let inCodeBlock = false;
+  let codeLang = "";
+
+  while (remaining.length > 0) {
+    // If remaining fits in one chunk, push it and done.
+    if (remaining.length <= effectiveMax) {
+      chunks.push(remaining);
+      break;
+    }
+
+    // We need to split. Find the best split point within effectiveMax.
+    const window = remaining.slice(0, effectiveMax);
+
+    // Determine the code-fence state within this window so we know
+    // if the split lands inside a code block.
+    const { splitIndex, insideFence, lang } = findSplitPoint(
+      window,
+      effectiveMax,
+      inCodeBlock,
+      codeLang,
+    );
+
+    let chunk = remaining.slice(0, splitIndex);
+    remaining = remaining.slice(splitIndex);
+
+    // Trim leading newlines from remaining (avoid empty-looking starts).
+    const trimmed = remaining.replace(/^\n{1,2}/, "");
+    remaining = trimmed;
+
+    // If we ended inside a code fence, close it in this chunk and
+    // reopen in the next.
+    if (insideFence) {
+      chunk = `${chunk}\n\`\`\``;
+      remaining = `\`\`\`${lang ? lang : ""}\n${remaining}`;
+      inCodeBlock = true;
+      codeLang = lang;
+    } else {
+      inCodeBlock = false;
+      codeLang = "";
+    }
+
+    if (chunk.trim().length > 0) {
+      chunks.push(chunk);
+    }
+  }
+
+  return chunks;
+};
+
+/**
+ * Find the best split point within the window text.
+ *
+ * Returns the character index to split at (exclusive), whether the split
+ * lands inside a code fence, and the fence's language tag if so.
+ */
+const findSplitPoint = (
+  window: string,
+  maxLength: number,
+  enteredInFence: boolean,
+  enteredLang: string,
+): { splitIndex: number; insideFence: boolean; lang: string } => {
+  // Track code fence state as we scan.
+  let inFence = enteredInFence;
+  let lang = enteredLang;
+
+  // Scan for code fences to know the state at any position.
+  // We collect fence toggle positions so we can determine state at split point.
+  const fenceToggles: Array<{
+    index: number;
+    opens: boolean;
+    lang: string;
+  }> = [];
+
+  const fenceRegex = /^(`{3,})(.*)?$/gm;
+  let match: RegExpExecArray | null = null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+  while ((match = fenceRegex.exec(window)) !== null) {
+    if (inFence) {
+      // This closes the fence.
+      fenceToggles.push({ index: match.index, opens: false, lang: "" });
+      inFence = false;
+      lang = "";
+    } else {
+      // This opens a fence.
+      const fenceLang = (match[2] ?? "").trim();
+      fenceToggles.push({
+        index: match.index,
+        opens: true,
+        lang: fenceLang,
+      });
+      inFence = true;
+      lang = fenceLang;
+    }
+  }
+
+  // Now determine the fence state at various candidate split points.
+  const fenceStateAt = (
+    pos: number,
+  ): { insideFence: boolean; lang: string } => {
+    let state = enteredInFence;
+    let currentLang = enteredLang;
+    for (const toggle of fenceToggles) {
+      if (toggle.index >= pos) {
+        break;
+      }
+      if (toggle.opens) {
+        state = true;
+        currentLang = toggle.lang;
+      } else {
+        state = false;
+        currentLang = "";
+      }
+    }
+    return { insideFence: state, lang: currentLang };
+  };
+
+  // Priority 1: Try to split on a paragraph boundary (\n\n).
+  // Search backwards from the end of the window for the last \n\n.
+  const lastParaBreak = window.lastIndexOf("\n\n");
+  if (lastParaBreak > 0) {
+    // Split after the double newline.
+    const splitAt = lastParaBreak;
+    const state = fenceStateAt(splitAt);
+    // Only use paragraph boundary if we're not splitting inside a code block,
+    // or if there's no better option.
+    if (!state.insideFence) {
+      return { splitIndex: splitAt, ...state };
+    }
+  }
+
+  // Priority 2: Try to split on a line boundary (\n).
+  const lastLineBreak = window.lastIndexOf("\n");
+  if (lastLineBreak > 0) {
+    const splitAt = lastLineBreak;
+    const state = fenceStateAt(splitAt);
+    return { splitIndex: splitAt, ...state };
+  }
+
+  // Priority 3: Hard cut at maxLength.
+  const state = fenceStateAt(maxLength);
+  return { splitIndex: maxLength, ...state };
+};
+
+/**
+ * Add part indicators to chunks: " (1/3)", " (2/3)", etc.
+ * Also appends the cost footer to the last chunk if provided.
+ */
+export const addChunkMetadata = (
+  chunks: string[],
+  costFooter?: string,
+): string[] => {
+  if (chunks.length === 0) {
+    return chunks;
+  }
+
+  // Single chunk: just append footer if present.
+  if (chunks.length === 1) {
+    const footer = costFooter ?? "";
+    return [chunks[0] + footer];
+  }
+
+  const total = chunks.length;
+  return chunks.map((chunk, i) => {
+    const indicator = ` (${String(i + 1)}/${String(total)})`;
+    const footer = i === total - 1 && costFooter ? costFooter : "";
+    return chunk + footer + indicator;
+  });
+};

--- a/apps/assistant-core/src/chunking.ts
+++ b/apps/assistant-core/src/chunking.ts
@@ -102,7 +102,6 @@ const findSplitPoint = (
 ): { splitIndex: number; insideFence: boolean; lang: string } => {
   // Track code fence state as we scan.
   let inFence = enteredInFence;
-  let lang = enteredLang;
 
   // Scan for code fences to know the state at any position.
   // We collect fence toggle positions so we can determine state at split point.
@@ -120,7 +119,6 @@ const findSplitPoint = (
       // This closes the fence.
       fenceToggles.push({ index: match.index, opens: false, lang: "" });
       inFence = false;
-      lang = "";
     } else {
       // This opens a fence.
       const fenceLang = (match[2] ?? "").trim();
@@ -130,7 +128,6 @@ const findSplitPoint = (
         lang: fenceLang,
       });
       inFence = true;
-      lang = fenceLang;
     }
   }
 

--- a/apps/assistant-core/src/messaging.ts
+++ b/apps/assistant-core/src/messaging.ts
@@ -57,6 +57,13 @@ export const sendMessage = async (
         error instanceof TelegramApiError &&
         error.statusCode === 400;
       if (!shouldRetryWithoutThread) {
+        if (i > 0) {
+          logInfo("chat.message.partial_send", {
+            chatId: outbound.chatId,
+            chunksSent: i,
+            chunksTotal: chunks.length,
+          });
+        }
         throw error;
       }
 

--- a/apps/assistant-core/src/messaging.ts
+++ b/apps/assistant-core/src/messaging.ts
@@ -22,7 +22,11 @@ export const sendMessage = async (
   fields: LogFields,
   costFooter?: string,
 ): Promise<void> => {
-  const rawChunks = splitMessage(outbound.text, TELEGRAM_MAX_LENGTH);
+  const rawChunks = splitMessage(
+    outbound.text,
+    TELEGRAM_MAX_LENGTH,
+    costFooter?.length ?? 0,
+  );
   const chunks = addChunkMetadata(rawChunks, costFooter);
 
   if (chunks.length > 1) {
@@ -33,7 +37,7 @@ export const sendMessage = async (
     });
   }
 
-  const threadId =
+  let threadId =
     outbound.threadId === undefined
       ? (ctx.lastThreadId.get(outbound.chatId) ?? null)
       : outbound.threadId;
@@ -62,6 +66,8 @@ export const sendMessage = async (
         droppedThreadId: threadId,
         reason: "telegram_400",
       });
+      // Clear threadId so remaining chunks don't repeat the failed attempt.
+      threadId = null;
     }
   }
 

--- a/apps/assistant-core/src/worker.ts
+++ b/apps/assistant-core/src/worker.ts
@@ -374,10 +374,9 @@ export const handleChatMessage = async (
             });
           }
 
-          const replyText = response.usage
-            ? response.replyText +
-              formatCostFooter(response.usage, response.tier)
-            : response.replyText;
+          const costFooter = response.usage
+            ? formatCostFooter(response.usage, response.tier)
+            : undefined;
 
           await sendMessage(
             ctx,
@@ -385,7 +384,7 @@ export const handleChatMessage = async (
             {
               chatId: message.chatId,
               threadId: message.threadId ?? null,
-              text: replyText,
+              text: response.replyText,
             },
             {
               action: "relay",
@@ -394,6 +393,7 @@ export const handleChatMessage = async (
               sessionKey,
               workspacePath: activeWorkspacePath,
             },
+            costFooter,
           );
           return;
         } catch (error) {

--- a/apps/assistant-core/tests/messaging.test.ts
+++ b/apps/assistant-core/tests/messaging.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { addChunkMetadata, splitMessage } from "@assistant-core/src/chunking";
 import { sendMessage } from "@assistant-core/src/messaging";
 import { WorkerContext } from "@assistant-core/src/worker-context";
 import type { OutboundMessage } from "@delegate/domain";
@@ -16,11 +17,158 @@ class CapturingChatPort implements ChatPort {
   }
 }
 
-describe("sendMessage truncation", () => {
-  test("sends short messages unmodified", async () => {
+// ---------------------------------------------------------------------------
+// splitMessage — unit tests
+// ---------------------------------------------------------------------------
+
+describe("splitMessage", () => {
+  test("returns single chunk for short text", () => {
+    const chunks = splitMessage("Hello, world!", 4096);
+    expect(chunks).toEqual(["Hello, world!"]);
+  });
+
+  test("returns single chunk for text exactly at limit", () => {
+    const text = "x".repeat(4096);
+    const chunks = splitMessage(text, 4096);
+    expect(chunks).toEqual([text]);
+  });
+
+  test("splits on paragraph boundary", () => {
+    const para1 = "a".repeat(3000);
+    const para2 = "b".repeat(3000);
+    const text = `${para1}\n\n${para2}`;
+
+    const chunks = splitMessage(text, 4096);
+    expect(chunks.length).toBe(2);
+    // First chunk should contain only a's (split at the paragraph boundary).
+    expect(chunks[0]).toBe(para1);
+    // Second chunk should contain only b's.
+    expect(chunks[1]).toBe(para2);
+  });
+
+  test("splits on line boundary when no paragraph break available", () => {
+    // Build a long text with only single-newline separators.
+    const lines = Array.from(
+      { length: 100 },
+      (_, i) => `Line ${String(i)}: ${"x".repeat(50)}`,
+    );
+    const text = lines.join("\n");
+
+    const chunks = splitMessage(text, 4096);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Each chunk should fit.
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(4096);
+    }
+    // Reconstruct: joining all chunks should reproduce all original lines.
+    const reconstructed = chunks.join("\n");
+    for (const line of lines) {
+      expect(reconstructed).toContain(line);
+    }
+  });
+
+  test("handles code fences — closes and reopens at chunk boundary", () => {
+    // Create a code block large enough to force splitting (> 4086 chars).
+    const codeContent = Array.from(
+      { length: 200 },
+      (_, i) =>
+        `  const value_${String(i)} = ${String(i)}; // ${"x".repeat(30)}`,
+    ).join("\n");
+    const text = `Some intro text.\n\n\`\`\`typescript\n${codeContent}\n\`\`\`\n\nSome outro.`;
+
+    expect(text.length).toBeGreaterThan(4096);
+
+    const chunks = splitMessage(text, 4096);
+    expect(chunks.length).toBeGreaterThan(1);
+
+    // Each chunk should fit within the limit.
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(4096);
+    }
+
+    // The first chunk with code should have an opening fence.
+    // Intermediate/continuation chunks should also have opening fences
+    // (from the reopen logic).
+    const allText = chunks.join("\n");
+    expect(allText).toContain("```typescript");
+  });
+
+  test("hard-cuts when no newlines available", () => {
+    const text = "x".repeat(10000);
+    const chunks = splitMessage(text, 4096);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(4096);
+    }
+  });
+
+  test("does not produce empty chunks", () => {
+    const text = `${"a".repeat(4000)}\n\n${"b".repeat(4000)}`;
+    const chunks = splitMessage(text, 4096);
+    for (const chunk of chunks) {
+      expect(chunk.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addChunkMetadata — unit tests
+// ---------------------------------------------------------------------------
+
+describe("addChunkMetadata", () => {
+  test("single chunk with no footer returns unchanged", () => {
+    const result = addChunkMetadata(["hello"]);
+    expect(result).toEqual(["hello"]);
+  });
+
+  test("single chunk with footer appends it", () => {
+    const result = addChunkMetadata(["hello"], "\n---\ncost");
+    expect(result).toEqual(["hello\n---\ncost"]);
+  });
+
+  test("multiple chunks get part indicators", () => {
+    const result = addChunkMetadata(["chunk1", "chunk2", "chunk3"]);
+    expect(result[0]).toBe("chunk1 (1/3)");
+    expect(result[1]).toBe("chunk2 (2/3)");
+    expect(result[2]).toBe("chunk3 (3/3)");
+  });
+
+  test("cost footer goes on last chunk only", () => {
+    const result = addChunkMetadata(["chunk1", "chunk2"], "\n---\n$0.05");
+    expect(result[0]).toBe("chunk1 (1/2)");
+    expect(result[1]).toBe("chunk2\n---\n$0.05 (2/2)");
+  });
+
+  test("empty array returns empty", () => {
+    const result = addChunkMetadata([]);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendMessage — integration tests
+// ---------------------------------------------------------------------------
+
+describe("sendMessage chunking", () => {
+  test("sends short messages as a single call", async () => {
     const ctx = new WorkerContext();
     const chatPort = new CapturingChatPort();
-    const text = "Hello, world!";
+
+    await sendMessage(
+      ctx,
+      chatPort,
+      { chatId: "c1", text: "Hello, world!" },
+      { action: "test" },
+    );
+
+    expect(chatPort.sent.length).toBe(1);
+    expect(chatPort.sent[0]!.text).toBe("Hello, world!");
+  });
+
+  test("sends exactly 4096-char messages as a single call", async () => {
+    const ctx = new WorkerContext();
+    const chatPort = new CapturingChatPort();
+    const text = "y".repeat(4096);
 
     await sendMessage(
       ctx,
@@ -29,38 +177,68 @@ describe("sendMessage truncation", () => {
       { action: "test" },
     );
 
+    expect(chatPort.sent.length).toBe(1);
     expect(chatPort.sent[0]!.text).toBe(text);
   });
 
-  test("truncates messages exceeding 4096 chars", async () => {
+  test("chunks long messages into multiple sends", async () => {
     const ctx = new WorkerContext();
     const chatPort = new CapturingChatPort();
-    const longText = "x".repeat(5000);
+    const text = "x".repeat(10000);
 
     await sendMessage(
       ctx,
       chatPort,
-      { chatId: "c1", text: longText },
+      { chatId: "c1", text },
       { action: "test" },
     );
 
-    const sent = chatPort.sent[0]!.text;
-    expect(sent.length).toBeLessThanOrEqual(4096);
-    expect(sent).toContain("(Message truncated)");
+    expect(chatPort.sent.length).toBeGreaterThan(1);
+    for (const msg of chatPort.sent) {
+      expect(msg.text.length).toBeLessThanOrEqual(4096);
+    }
+    // Last chunk should have part indicator.
+    const last = chatPort.sent[chatPort.sent.length - 1]!;
+    expect(last.text).toMatch(/\(\d+\/\d+\)$/);
   });
 
-  test("leaves exactly 4096-char messages untouched", async () => {
+  test("cost footer appears only on last chunk", async () => {
     const ctx = new WorkerContext();
     const chatPort = new CapturingChatPort();
-    const exactText = "y".repeat(4096);
+    const text = `${"a".repeat(4000)}\n\n${"b".repeat(4000)}`;
+    const footer = "\n\n---\n💰 $0.05 | 12.5k tokens";
 
     await sendMessage(
       ctx,
       chatPort,
-      { chatId: "c1", text: exactText },
+      { chatId: "c1", text },
       { action: "test" },
+      footer,
     );
 
-    expect(chatPort.sent[0]!.text).toBe(exactText);
+    expect(chatPort.sent.length).toBeGreaterThan(1);
+    // Only last message should contain the cost footer.
+    for (let i = 0; i < chatPort.sent.length - 1; i++) {
+      expect(chatPort.sent[i]!.text).not.toContain("$0.05");
+    }
+    const last = chatPort.sent[chatPort.sent.length - 1]!;
+    expect(last.text).toContain("$0.05");
+  });
+
+  test("cost footer on short message works normally", async () => {
+    const ctx = new WorkerContext();
+    const chatPort = new CapturingChatPort();
+    const footer = "\n\n---\n💰 $0.01";
+
+    await sendMessage(
+      ctx,
+      chatPort,
+      { chatId: "c1", text: "Short reply" },
+      { action: "test" },
+      footer,
+    );
+
+    expect(chatPort.sent.length).toBe(1);
+    expect(chatPort.sent[0]!.text).toBe("Short reply\n\n---\n💰 $0.01");
   });
 });

--- a/apps/assistant-core/tests/messaging.test.ts
+++ b/apps/assistant-core/tests/messaging.test.ts
@@ -110,6 +110,23 @@ describe("splitMessage", () => {
     }
   });
 
+  test("fence closer does not push chunk over limit (hard cut inside code fence)", () => {
+    // A single code block with no newlines — forces a hard cut at effectiveMax
+    // inside the fence. The "\n```" closer (4 chars) must not push the chunk
+    // over maxLength after the part indicator is added.
+    const maxLen = 4096;
+    const codeBody = "x".repeat(maxLen * 3);
+    const text = `\`\`\`typescript\n${codeBody}\n\`\`\``;
+
+    const rawChunks = splitMessage(text, maxLen);
+    const chunks = addChunkMetadata(rawChunks);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(maxLen);
+    }
+  });
+
   test("reserves extra space on last chunk when lastChunkReserve is set", () => {
     const reserve = 50;
     // Text that just barely doesn't fit in a single chunk with the reserve.


### PR DESCRIPTION
## Summary

Fixes [#77](https://github.com/shetty4l/delegate-assistant/issues/77). Long model responses are now split into multiple Telegram messages instead of being hard-truncated at 4096 characters with a `(Message truncated)` suffix.

- **Markdown-aware splitting**: respects paragraph boundaries, line breaks, and code fences
- **Code fence tracking**: fences are closed/reopened at chunk boundaries so each message is valid markdown
- **Part indicators**: multi-chunk messages get `(1/3)`, `(2/3)`, `(3/3)` suffixes
- **Cost footer on last chunk**: never lost to truncation

## Problem

When the model produced a response > 4096 chars, everything beyond char 4072 was permanently lost. The cost footer (appended before truncation) was also cut on long messages. This cascaded into repeated failures because the issue description itself showed a truncated response that confused subsequent interactions.

## Before vs After

| | Before | After |
|---|---|---|
| Long response | Hard-truncated + `(Message truncated)` | Split into multiple messages |
| Content loss | Everything beyond 4072 chars gone | No content lost |
| Code blocks | Could be cut mid-fence | Fences closed/reopened at boundaries |
| Cost footer | Appended before truncation, often cut | Always on last chunk |

## Implementation

### New: `chunking.ts`

`splitMessage(text, maxLength)` — splits text into chunks with this priority:
1. **Paragraph boundary** (`\n\n`) — keeps paragraphs intact
2. **Line boundary** (`\n`) — never breaks mid-line
3. **Hard cut** — last resort for text with no newlines

Code fence state machine tracks opening/closing of triple-backtick blocks. If a chunk ends inside a code fence, it's closed with ` ``` ` and reopened (with the language tag) at the start of the next chunk.

`addChunkMetadata(chunks, costFooter?)` — adds `(1/N)` indicators and appends cost footer to the last chunk only.

### Changed: `messaging.ts`

Replaced the truncation logic with chunked multi-send. New optional `costFooter` parameter on `sendMessage()` — the footer is passed through to `addChunkMetadata` instead of being concatenated by the worker before send.

### Changed: `worker.ts`

Cost footer is now passed as a separate parameter to `sendMessage()` instead of being concatenated to `replyText`. One-line change.

## Tests

17 tests covering:
- `splitMessage`: paragraph/line/hard-cut splitting, code fence handling, no empty chunks
- `addChunkMetadata`: single chunk passthrough, multi-chunk indicators, cost footer placement
- `sendMessage` integration: short messages unchanged, exact-limit passthrough, long messages chunked, cost footer on last chunk only

## Verification

- `bun run verify` green (typecheck, format, lint, build:web, 281 tests, docs)

Closes #77